### PR TITLE
Set specific color for each kind of path, change colors for cycle routes

### DIFF
--- a/placenames.mss
+++ b/placenames.mss
@@ -374,32 +374,18 @@
 
 #placenames-small::quarter {
   [place = 'quarter'] {
-    [zoom >= 14][zoom < 17] {
+    [zoom >= 16][zoom <= 17] {
       text-name: "[name]";
       text-fill: @placenames;
       text-face-name: @sans;
       text-halo-fill: @other_halo;
       text-halo-radius: @standard-halo-radius * 1.5;
-      [zoom >= 14] {
-        text-halo-fill: white;
-        text-size: 11;
-        text-wrap-width: 55; // 5.0 em
-        text-line-spacing: -0.55; // -0.05 em
-        text-margin: 7.7; // 0.7 em
-      }
-      [zoom >= 15] {
-        text-fill: @placenames-light;
-        text-size: 12;
-        text-wrap-width: 60; // 5.0 em
-        text-line-spacing: -0.60; // -0.05 em
-        text-margin: 8.4; // 0.7 em
-      }
-      [zoom >= 16] {
-        text-size: 14;
-        text-wrap-width: 70; // 5.0 em
-        text-line-spacing: -0.70; // -0.05 em
-        text-margin: 9.8; // 0.7 em
-      }
+      text-halo-fill: white;
+      text-fill: @placenames-light;
+      text-wrap-width: 60; // 5.0 em
+      text-line-spacing: -0.60; // -0.05 em
+      text-margin: 8.4; // 0.7 em
+      text-size: 12;
     }
   }
   [place = 'hamlet'] {

--- a/road-colors-generated.mss
+++ b/road-colors-generated.mss
@@ -4,12 +4,12 @@
 /*                                                                       */
 /*   ./scripts/generate_road_colors.py | tee road-colors-generated.mss   */
 /*                                                                       */
-@bridleway-fill: #ff3f00;
+@bridleway-fill: #ff1700;
 @cycle-case: @land;
 @cycle-fill: #0000ff;
 @cycle-line: @standard_line;
 @footway-fill: #007200;
-@icn-overlay: #0b910b;
+@icn-overlay: #ff00ff;
 @icn-shield-fill: #f6f6f6;
 @lcn-overlay: #0000ff;
 @lcn-shield-fill: #f6f6f6;
@@ -19,7 +19,7 @@
 @motorway-shield-fill: #620728;
 @mtb-overlay: #ff6200;
 @mtb-shield-fill: #f6f6f6;
-@ncn-overlay: #ff0000;
+@ncn-overlay: #aa00ff;
 @ncn-shield-fill: #f6f6f6;
 @path-fill: #873100;
 @pedestrian-case: @land;
@@ -30,7 +30,7 @@
 @primary-line: #f4dfc3;
 @primary-shield-fill: #4c2e00;
 @rail-line: #999999;
-@rcn-overlay: #b42dff;
+@rcn-overlay: #5500ff;
 @rcn-shield-fill: #f6f6f6;
 @secondary-case: #b1bb5d;
 @secondary-fill: #f6f8d2;

--- a/road-colors-generated.mss
+++ b/road-colors-generated.mss
@@ -4,9 +4,11 @@
 /*                                                                       */
 /*   ./scripts/generate_road_colors.py | tee road-colors-generated.mss   */
 /*                                                                       */
+@bridleway-fill: #ff3f00;
 @cycle-case: @land;
 @cycle-fill: #0000ff;
 @cycle-line: @standard_line;
+@footway-fill: #007200;
 @icn-overlay: #0b910b;
 @icn-shield-fill: #f6f6f6;
 @lcn-overlay: #0000ff;
@@ -19,8 +21,9 @@
 @mtb-shield-fill: #f6f6f6;
 @ncn-overlay: #ff0000;
 @ncn-shield-fill: #f6f6f6;
+@path-fill: #873100;
 @pedestrian-case: @land;
-@pedestrian-fill: #ff0000;
+@pedestrian-fill: #007200;
 @pedestrian-line: @standard_line;
 @primary-case: #d8b267;
 @primary-fill: #f4dfc3;
@@ -39,7 +42,7 @@
 @standard-fill: #f6f6f6;
 @standard-line: #f6f6f6;
 @steps-case: @land;
-@steps-fill: #9a2a00;
+@steps-fill: #003e00;
 @tertiary-case: #686868;
 @tertiary-fill: #f6f6f6;
 @tertiary-line: #f6f6f6;

--- a/road-colors.yml
+++ b/road-colors.yml
@@ -62,13 +62,13 @@ mss:
   rail:
     line: '#999999'
   icn:
-    overlay: '#0b910b'
+    overlay: '#ff00ff'
     shield-fill: '#f6f6f6'
   ncn:
-    overlay: '#ff0000'
+    overlay: '#aa00ff'
     shield-fill: '#f6f6f6'
   rcn:
-    overlay: '#b42dff'
+    overlay: '#5500ff'
     shield-fill: '#f6f6f6'
   lcn:
     overlay: '#0000ff'
@@ -94,14 +94,14 @@ shield:
     fill: '#f1f1f1'
     stroke_fill: '#c6c6c6'
   icn:
-    fill: '#0b910b'
-    stroke_fill: '#0b910b'
+    fill: '#ff00ff'
+    stroke_fill: '#ff00ff'
   ncn:
-    fill: '#ff0000'
-    stroke_fill: '#ff0000'
+    fill: '#aa00ff'
+    stroke_fill: '#aa00ff'
   rcn:
-    fill: '#b42dff'
-    stroke_fill: '#b42dff'
+    fill: '#5500ff'
+    stroke_fill: '#5500ff'
   lcn:
     fill: '#0000ff'
     stroke_fill: '#0000ff'

--- a/road-colors.yml
+++ b/road-colors.yml
@@ -44,15 +44,21 @@ mss:
     fill: '#4bffff'
   pedestrian:
     line: '@standard_line'
-    fill: '#ff0000'
+    fill: '#007200'
     case: '@land'
   cycle:
     line: '@standard_line'
     fill: '#0000ff'
     case: '@land'
+  footway:
+    fill: '#007200'
   steps:
-    fill: '#9a2a00'
+    fill: '#003e00'
     case: '@land'
+  path:
+    fill: '#873100'
+  bridleway:
+    fill: '#ff1700'
   rail:
     line: '#999999'
   icn:

--- a/roads.mss
+++ b/roads.mss
@@ -901,11 +901,17 @@ come in as well.
   [type='secondary_link'] {
     line-color: @secondary-fill;
   }
-  [type='path'],
-  [type='pedestrian'],
-  [type='bridleway'],
-  [type='footway'] {
+  [type='path'] {
+    line-color: @path-fill;
+  }
+  [type='pedestrian'] {
     line-color: @pedestrian-fill;
+  }
+  [type='bridleway'] {
+    line-color: @bridleway-fill;
+  }
+  [type='footway'] {
+    line-color: @footway-fill;
   }
   [type='cycleway'],
   [type='path'][bicycle='yes'],
@@ -1597,11 +1603,17 @@ come in as well.
   [type='secondary_link'] {
     line-color: @secondary-fill;
   }
-  [type='pedestrian'],
-  [type='bridleway'],
-  [type='footway'],
   [type='path'] {
+    line-color: @path-fill;
+  }
+  [type='pedestrian'] {
     line-color: @pedestrian-fill;
+  }
+  [type='bridleway'] {
+    line-color: @bridleway-fill;
+  }
+  [type='footway'] {
+    line-color: @footway-fill;
   }
   [type='steps'] {
     line-color: @steps-fill;
@@ -2427,11 +2439,17 @@ come in as well.
   [type='pedestrian'][bicycle='designated'] {
     line-color: @cycle-fill;
   }
-  [type='pedestrian'],
-  [type='bridleway'],
-  [type='footway'],
   [type='path'] {
+    line-color: @path-fill;
+  }
+  [type='pedestrian'] {
     line-color: @pedestrian-fill;
+  }
+  [type='bridleway'] {
+    line-color: @bridleway-fill;
+  }
+  [type='footway'] {
+    line-color: @footway-fill;
   }
   [type='steps'] {
     line-color: @steps-fill;
@@ -2574,10 +2592,10 @@ come in as well.
     [type='tertiary']   { line-width: @rdz13_tertiary }
     [type='service']      { line-width: @rdz13_service; }
     [type='track']      { line-width: @rdz13_track; }
-    [type='pedestrian']   { line-width: @rdz13_pedestrian; line-dasharray: 1,1; }
-    [type='bridleway']   { line-width: @rdz13_bridleway; line-dasharray: 1,1; }
-    [type='footway']   { line-width: @rdz13_footway; line-dasharray: 1,1; }
-    [type='path']   { line-width: @rdz13_path; line-dasharray: 1,1; }
+    [type='pedestrian']   { line-width: @rdz13_pedestrian; }
+    [type='bridleway']   { line-width: @rdz13_bridleway; line-dasharray: 1,1;}
+    [type='footway']   { line-width: @rdz13_footway; }
+    [type='path']   { line-width: @rdz13_path; }
     [type='steps']        { line-width: @rdz13_steps;      line-dasharray: 0.5,0.5; }
     [type='cycleway'],
     [type='path'][bicycle='yes'],
@@ -2609,10 +2627,10 @@ come in as well.
     [type='motorway_link']    { line-width: @rdz14_motorway_link; }
     [type='service']      { line-width: @rdz14_service; }
     [type='track']      { line-width: @rdz14_track; }
-    [type='pedestrian']   { line-width: @rdz14_pedestrian; line-dasharray: 1,1; }
+    [type='pedestrian']   { line-width: @rdz14_pedestrian; }
     [type='bridleway']   { line-width: @rdz14_bridleway; line-dasharray: 1,1; }
-    [type='footway']   { line-width: @rdz14_footway; line-dasharray: 1,1; }
-    [type='path']   { line-width: @rdz14_path; line-dasharray: 1,1; }
+    [type='footway']   { line-width: @rdz14_footway; }
+    [type='path']   { line-width: @rdz14_path; }
     [type='steps']        { line-width: @rdz14_steps;      line-dasharray: 0.5,0.5; }
     [type='cycleway'],
     [type='path'][bicycle='yes'],
@@ -2644,10 +2662,10 @@ come in as well.
     [type='motorway_link']    { line-width: @rdz15_motorway_link; }
     [type='service']      { line-width: @rdz15_service; }
     [type='track']      { line-width: @rdz15_track; }
-    [type='pedestrian']   { line-width: @rdz15_pedestrian; line-dasharray: 1,1; }
+    [type='pedestrian']   { line-width: @rdz15_pedestrian; }
     [type='bridleway']   { line-width: @rdz15_bridleway; line-dasharray: 1,1; }
-    [type='footway']   { line-width: @rdz15_footway; line-dasharray: 1,1; }
-    [type='path']   { line-width: @rdz15_path; line-dasharray: 1,1; }
+    [type='footway']   { line-width: @rdz15_footway; }
+    [type='path']   { line-width: @rdz15_path; }
     [type='steps']        { line-width: @rdz15_steps;      line-dasharray: 0.5,0.5; }
     [type='cycleway'],
     [type='path'][bicycle='yes'],
@@ -2679,10 +2697,10 @@ come in as well.
     [type='motorway_link']    { line-width: @rdz16_motorway_link; }
     [type='service']      { line-width: @rdz16_service; }
     [type='track']      { line-width: @rdz16_track; }
-    [type='pedestrian']   { line-width: @rdz16_pedestrian; line-dasharray: 2,1; }
+    [type='pedestrian']   { line-width: @rdz16_pedestrian; }
     [type='bridleway']   { line-width: @rdz16_bridleway; line-dasharray: 2,1; }
-    [type='footway']   { line-width: @rdz16_footway; line-dasharray: 2,1; }
-    [type='path']   { line-width: @rdz16_path; line-dasharray: 2,1; }
+    [type='footway']   { line-width: @rdz16_footway; }
+    [type='path']   { line-width: @rdz16_path; }
     [type='steps']        { line-width: @rdz16_steps;      line-dasharray: 1.5,0.75; }
     [type='cycleway'],
     [type='path'][bicycle='yes'],
@@ -2714,10 +2732,10 @@ come in as well.
     [type='motorway_link']    { line-width: @rdz17_motorway_link; }
     [type='service']      { line-width: @rdz17_service; }
     [type='track']      { line-width: @rdz17_track; }
-    [type='pedestrian']   { line-width: @rdz17_pedestrian; line-dasharray: 2,2; }
+    [type='pedestrian']   { line-width: @rdz17_pedestrian; }
     [type='bridleway']   { line-width: @rdz17_bridleway; line-dasharray: 2,2; }
-    [type='footway']   { line-width: @rdz17_footway; line-dasharray: 2,2; }
-    [type='path']   { line-width: @rdz17_path; line-dasharray: 2,2; }
+    [type='footway']   { line-width: @rdz17_footway; }
+    [type='path']   { line-width: @rdz17_path; }
     [type='steps']        { line-width: @rdz17_steps;      line-dasharray: 2,1; }
     [type='cycleway'],
     [type='path'][bicycle='yes'],
@@ -2749,10 +2767,10 @@ come in as well.
     [type='motorway_link']    { line-width: @rdz18_motorway_link; }
     [type='service']      { line-width: @rdz18_service; }
     [type='track']      { line-width: @rdz18_track; }
-    [type='pedestrian']   { line-width: @rdz18_pedestrian; line-dasharray: 3,3; }
+    [type='pedestrian']   { line-width: @rdz18_pedestrian; }
     [type='bridleway']   { line-width: @rdz18_bridleway; line-dasharray: 3,3; }
-    [type='footway']   { line-width: @rdz18_footway; line-dasharray: 3,3; }
-    [type='path']   { line-width: @rdz18_path; line-dasharray: 3,3; }
+    [type='footway']   { line-width: @rdz18_footway; }
+    [type='path']   { line-width: @rdz18_path; }
     [type='steps']        { line-width: @rdz18_steps;      line-dasharray: 2,1; }
     [type='cycleway'],
     [type='path'][bicycle='yes'],

--- a/roads.mss
+++ b/roads.mss
@@ -2870,14 +2870,14 @@ come in as well.
 #bicycle_routes[type='ncn'][zoom >= 5],
 #bicycle_routes[type='rcn'][zoom >= 7],
 #bicycle_routes[type='lcn'][zoom >= 9] {
-  line-opacity: 0.3;
+  line-opacity: 0.2;
   line-width: 1;
 
-  [zoom <= 12] { line-opacity: 0.6; }
+  [zoom <= 12] { line-opacity: 0.5; }
 
   [zoom=9]   { line-width: 2; }
   [zoom>=10] { line-width: 3; }
-  [zoom=13]  { line-width: 4; line-opacity: 0.45; }
+  [zoom=13]  { line-width: 4; line-opacity: 0.35; }
   [zoom=14]  { line-width: 5; }
   [zoom=15]  { line-width: 6; }
   [zoom=16]  { line-width: 7; }
@@ -2901,7 +2901,7 @@ come in as well.
   }
 
   [state='proposed'] {
-    line-dasharray: 6,3;
+    line-dasharray: 6,6;
   }
 }
 

--- a/symbols/shields/icn_10x1.svg
+++ b/symbols/shields/icn_10x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 18">
-  <rect x="0.5" y="0.5" width="70.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x1_z16.svg
+++ b/symbols/shields/icn_10x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 20">
-  <rect x="0.5" y="0.5" width="69.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x1_z18.svg
+++ b/symbols/shields/icn_10x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 21">
-  <rect x="0.5" y="0.5" width="77.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x2.svg
+++ b/symbols/shields/icn_10x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 30">
-  <rect x="0.5" y="0.5" width="70.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x2_z16.svg
+++ b/symbols/shields/icn_10x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 34">
-  <rect x="0.5" y="0.5" width="69.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x2_z18.svg
+++ b/symbols/shields/icn_10x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 36">
-  <rect x="0.5" y="0.5" width="77.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x3.svg
+++ b/symbols/shields/icn_10x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 42">
-  <rect x="0.5" y="0.5" width="70.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x3_z16.svg
+++ b/symbols/shields/icn_10x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 48">
-  <rect x="0.5" y="0.5" width="69.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x3_z18.svg
+++ b/symbols/shields/icn_10x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 51">
-  <rect x="0.5" y="0.5" width="77.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x4.svg
+++ b/symbols/shields/icn_10x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 54">
-  <rect x="0.5" y="0.5" width="70.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x4_z16.svg
+++ b/symbols/shields/icn_10x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 62">
-  <rect x="0.5" y="0.5" width="69.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_10x4_z18.svg
+++ b/symbols/shields/icn_10x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 66">
-  <rect x="0.5" y="0.5" width="77.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x1.svg
+++ b/symbols/shields/icn_11x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 18">
-  <rect x="0.5" y="0.5" width="77.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x1_z16.svg
+++ b/symbols/shields/icn_11x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 20">
-  <rect x="0.5" y="0.5" width="76.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x1_z18.svg
+++ b/symbols/shields/icn_11x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 21">
-  <rect x="0.5" y="0.5" width="84.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x2.svg
+++ b/symbols/shields/icn_11x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 30">
-  <rect x="0.5" y="0.5" width="77.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x2_z16.svg
+++ b/symbols/shields/icn_11x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 34">
-  <rect x="0.5" y="0.5" width="76.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x2_z18.svg
+++ b/symbols/shields/icn_11x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 36">
-  <rect x="0.5" y="0.5" width="84.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x3.svg
+++ b/symbols/shields/icn_11x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 42">
-  <rect x="0.5" y="0.5" width="77.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x3_z16.svg
+++ b/symbols/shields/icn_11x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 48">
-  <rect x="0.5" y="0.5" width="76.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x3_z18.svg
+++ b/symbols/shields/icn_11x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 51">
-  <rect x="0.5" y="0.5" width="84.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x4.svg
+++ b/symbols/shields/icn_11x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 54">
-  <rect x="0.5" y="0.5" width="77.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x4_z16.svg
+++ b/symbols/shields/icn_11x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 62">
-  <rect x="0.5" y="0.5" width="76.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_11x4_z18.svg
+++ b/symbols/shields/icn_11x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 66">
-  <rect x="0.5" y="0.5" width="84.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x1.svg
+++ b/symbols/shields/icn_1x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 18">
-  <rect x="0.5" y="0.5" width="15.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x1_z16.svg
+++ b/symbols/shields/icn_1x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 20">
-  <rect x="0.5" y="0.5" width="15.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x1_z18.svg
+++ b/symbols/shields/icn_1x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 21">
-  <rect x="0.5" y="0.5" width="15.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x2.svg
+++ b/symbols/shields/icn_1x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 30">
-  <rect x="0.5" y="0.5" width="15.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x2_z16.svg
+++ b/symbols/shields/icn_1x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 34">
-  <rect x="0.5" y="0.5" width="15.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x2_z18.svg
+++ b/symbols/shields/icn_1x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 36">
-  <rect x="0.5" y="0.5" width="15.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x3.svg
+++ b/symbols/shields/icn_1x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 42">
-  <rect x="0.5" y="0.5" width="15.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x3_z16.svg
+++ b/symbols/shields/icn_1x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 48">
-  <rect x="0.5" y="0.5" width="15.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x3_z18.svg
+++ b/symbols/shields/icn_1x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 51">
-  <rect x="0.5" y="0.5" width="15.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x4.svg
+++ b/symbols/shields/icn_1x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 54">
-  <rect x="0.5" y="0.5" width="15.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x4_z16.svg
+++ b/symbols/shields/icn_1x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 62">
-  <rect x="0.5" y="0.5" width="15.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_1x4_z18.svg
+++ b/symbols/shields/icn_1x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 66">
-  <rect x="0.5" y="0.5" width="15.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x1.svg
+++ b/symbols/shields/icn_2x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 18">
-  <rect x="0.5" y="0.5" width="21.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x1_z16.svg
+++ b/symbols/shields/icn_2x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 20">
-  <rect x="0.5" y="0.5" width="21.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x1_z18.svg
+++ b/symbols/shields/icn_2x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 21">
-  <rect x="0.5" y="0.5" width="22.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x2.svg
+++ b/symbols/shields/icn_2x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 30">
-  <rect x="0.5" y="0.5" width="21.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x2_z16.svg
+++ b/symbols/shields/icn_2x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 34">
-  <rect x="0.5" y="0.5" width="21.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x2_z18.svg
+++ b/symbols/shields/icn_2x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 36">
-  <rect x="0.5" y="0.5" width="22.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x3.svg
+++ b/symbols/shields/icn_2x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 42">
-  <rect x="0.5" y="0.5" width="21.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x3_z16.svg
+++ b/symbols/shields/icn_2x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 48">
-  <rect x="0.5" y="0.5" width="21.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x3_z18.svg
+++ b/symbols/shields/icn_2x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 51">
-  <rect x="0.5" y="0.5" width="22.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x4.svg
+++ b/symbols/shields/icn_2x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 54">
-  <rect x="0.5" y="0.5" width="21.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x4_z16.svg
+++ b/symbols/shields/icn_2x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 62">
-  <rect x="0.5" y="0.5" width="21.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_2x4_z18.svg
+++ b/symbols/shields/icn_2x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 66">
-  <rect x="0.5" y="0.5" width="22.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x1.svg
+++ b/symbols/shields/icn_3x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 18">
-  <rect x="0.5" y="0.5" width="27.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x1_z16.svg
+++ b/symbols/shields/icn_3x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 20">
-  <rect x="0.5" y="0.5" width="27.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x1_z18.svg
+++ b/symbols/shields/icn_3x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 21">
-  <rect x="0.5" y="0.5" width="29.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x2.svg
+++ b/symbols/shields/icn_3x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 30">
-  <rect x="0.5" y="0.5" width="27.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x2_z16.svg
+++ b/symbols/shields/icn_3x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 34">
-  <rect x="0.5" y="0.5" width="27.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x2_z18.svg
+++ b/symbols/shields/icn_3x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 36">
-  <rect x="0.5" y="0.5" width="29.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x3.svg
+++ b/symbols/shields/icn_3x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 42">
-  <rect x="0.5" y="0.5" width="27.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x3_z16.svg
+++ b/symbols/shields/icn_3x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 48">
-  <rect x="0.5" y="0.5" width="27.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x3_z18.svg
+++ b/symbols/shields/icn_3x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 51">
-  <rect x="0.5" y="0.5" width="29.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x4.svg
+++ b/symbols/shields/icn_3x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 54">
-  <rect x="0.5" y="0.5" width="27.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x4_z16.svg
+++ b/symbols/shields/icn_3x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 62">
-  <rect x="0.5" y="0.5" width="27.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_3x4_z18.svg
+++ b/symbols/shields/icn_3x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 66">
-  <rect x="0.5" y="0.5" width="29.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x1.svg
+++ b/symbols/shields/icn_4x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 18">
-  <rect x="0.5" y="0.5" width="33.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x1_z16.svg
+++ b/symbols/shields/icn_4x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 20">
-  <rect x="0.5" y="0.5" width="33.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x1_z18.svg
+++ b/symbols/shields/icn_4x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 21">
-  <rect x="0.5" y="0.5" width="36.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x2.svg
+++ b/symbols/shields/icn_4x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 30">
-  <rect x="0.5" y="0.5" width="33.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x2_z16.svg
+++ b/symbols/shields/icn_4x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 34">
-  <rect x="0.5" y="0.5" width="33.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x2_z18.svg
+++ b/symbols/shields/icn_4x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 36">
-  <rect x="0.5" y="0.5" width="36.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x3.svg
+++ b/symbols/shields/icn_4x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 42">
-  <rect x="0.5" y="0.5" width="33.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x3_z16.svg
+++ b/symbols/shields/icn_4x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 48">
-  <rect x="0.5" y="0.5" width="33.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x3_z18.svg
+++ b/symbols/shields/icn_4x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 51">
-  <rect x="0.5" y="0.5" width="36.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x4.svg
+++ b/symbols/shields/icn_4x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 54">
-  <rect x="0.5" y="0.5" width="33.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x4_z16.svg
+++ b/symbols/shields/icn_4x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 62">
-  <rect x="0.5" y="0.5" width="33.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_4x4_z18.svg
+++ b/symbols/shields/icn_4x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 66">
-  <rect x="0.5" y="0.5" width="36.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x1.svg
+++ b/symbols/shields/icn_5x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 18">
-  <rect x="0.5" y="0.5" width="39.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x1_z16.svg
+++ b/symbols/shields/icn_5x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 20">
-  <rect x="0.5" y="0.5" width="39.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x1_z18.svg
+++ b/symbols/shields/icn_5x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 21">
-  <rect x="0.5" y="0.5" width="43.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x2.svg
+++ b/symbols/shields/icn_5x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 30">
-  <rect x="0.5" y="0.5" width="39.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x2_z16.svg
+++ b/symbols/shields/icn_5x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 34">
-  <rect x="0.5" y="0.5" width="39.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x2_z18.svg
+++ b/symbols/shields/icn_5x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 36">
-  <rect x="0.5" y="0.5" width="43.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x3.svg
+++ b/symbols/shields/icn_5x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 42">
-  <rect x="0.5" y="0.5" width="39.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x3_z16.svg
+++ b/symbols/shields/icn_5x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 48">
-  <rect x="0.5" y="0.5" width="39.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x3_z18.svg
+++ b/symbols/shields/icn_5x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 51">
-  <rect x="0.5" y="0.5" width="43.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x4.svg
+++ b/symbols/shields/icn_5x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 54">
-  <rect x="0.5" y="0.5" width="39.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x4_z16.svg
+++ b/symbols/shields/icn_5x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 62">
-  <rect x="0.5" y="0.5" width="39.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_5x4_z18.svg
+++ b/symbols/shields/icn_5x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 66">
-  <rect x="0.5" y="0.5" width="43.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x1.svg
+++ b/symbols/shields/icn_6x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 18">
-  <rect x="0.5" y="0.5" width="46.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x1_z16.svg
+++ b/symbols/shields/icn_6x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 20">
-  <rect x="0.5" y="0.5" width="45.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x1_z18.svg
+++ b/symbols/shields/icn_6x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 21">
-  <rect x="0.5" y="0.5" width="50.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x2.svg
+++ b/symbols/shields/icn_6x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 30">
-  <rect x="0.5" y="0.5" width="46.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x2_z16.svg
+++ b/symbols/shields/icn_6x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 34">
-  <rect x="0.5" y="0.5" width="45.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x2_z18.svg
+++ b/symbols/shields/icn_6x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 36">
-  <rect x="0.5" y="0.5" width="50.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x3.svg
+++ b/symbols/shields/icn_6x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 42">
-  <rect x="0.5" y="0.5" width="46.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x3_z16.svg
+++ b/symbols/shields/icn_6x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 48">
-  <rect x="0.5" y="0.5" width="45.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x3_z18.svg
+++ b/symbols/shields/icn_6x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 51">
-  <rect x="0.5" y="0.5" width="50.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x4.svg
+++ b/symbols/shields/icn_6x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 54">
-  <rect x="0.5" y="0.5" width="46.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x4_z16.svg
+++ b/symbols/shields/icn_6x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 62">
-  <rect x="0.5" y="0.5" width="45.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_6x4_z18.svg
+++ b/symbols/shields/icn_6x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 66">
-  <rect x="0.5" y="0.5" width="50.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x1.svg
+++ b/symbols/shields/icn_7x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 18">
-  <rect x="0.5" y="0.5" width="52.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x1_z16.svg
+++ b/symbols/shields/icn_7x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 20">
-  <rect x="0.5" y="0.5" width="51.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x1_z18.svg
+++ b/symbols/shields/icn_7x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 21">
-  <rect x="0.5" y="0.5" width="57.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x2.svg
+++ b/symbols/shields/icn_7x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 30">
-  <rect x="0.5" y="0.5" width="52.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x2_z16.svg
+++ b/symbols/shields/icn_7x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 34">
-  <rect x="0.5" y="0.5" width="51.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x2_z18.svg
+++ b/symbols/shields/icn_7x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 36">
-  <rect x="0.5" y="0.5" width="57.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x3.svg
+++ b/symbols/shields/icn_7x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 42">
-  <rect x="0.5" y="0.5" width="52.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x3_z16.svg
+++ b/symbols/shields/icn_7x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 48">
-  <rect x="0.5" y="0.5" width="51.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x3_z18.svg
+++ b/symbols/shields/icn_7x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 51">
-  <rect x="0.5" y="0.5" width="57.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x4.svg
+++ b/symbols/shields/icn_7x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 54">
-  <rect x="0.5" y="0.5" width="52.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x4_z16.svg
+++ b/symbols/shields/icn_7x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 62">
-  <rect x="0.5" y="0.5" width="51.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_7x4_z18.svg
+++ b/symbols/shields/icn_7x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 66">
-  <rect x="0.5" y="0.5" width="57.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x1.svg
+++ b/symbols/shields/icn_8x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 18">
-  <rect x="0.5" y="0.5" width="58.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x1_z16.svg
+++ b/symbols/shields/icn_8x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 20">
-  <rect x="0.5" y="0.5" width="57.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x1_z18.svg
+++ b/symbols/shields/icn_8x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 21">
-  <rect x="0.5" y="0.5" width="64.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x2.svg
+++ b/symbols/shields/icn_8x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 30">
-  <rect x="0.5" y="0.5" width="58.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x2_z16.svg
+++ b/symbols/shields/icn_8x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 34">
-  <rect x="0.5" y="0.5" width="57.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x2_z18.svg
+++ b/symbols/shields/icn_8x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 36">
-  <rect x="0.5" y="0.5" width="64.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x3.svg
+++ b/symbols/shields/icn_8x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 42">
-  <rect x="0.5" y="0.5" width="58.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x3_z16.svg
+++ b/symbols/shields/icn_8x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 48">
-  <rect x="0.5" y="0.5" width="57.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x3_z18.svg
+++ b/symbols/shields/icn_8x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 51">
-  <rect x="0.5" y="0.5" width="64.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x4.svg
+++ b/symbols/shields/icn_8x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 54">
-  <rect x="0.5" y="0.5" width="58.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x4_z16.svg
+++ b/symbols/shields/icn_8x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 62">
-  <rect x="0.5" y="0.5" width="57.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_8x4_z18.svg
+++ b/symbols/shields/icn_8x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 66">
-  <rect x="0.5" y="0.5" width="64.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x1.svg
+++ b/symbols/shields/icn_9x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 18">
-  <rect x="0.5" y="0.5" width="64.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x1_z16.svg
+++ b/symbols/shields/icn_9x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 20">
-  <rect x="0.5" y="0.5" width="63.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x1_z18.svg
+++ b/symbols/shields/icn_9x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 21">
-  <rect x="0.5" y="0.5" width="71.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x2.svg
+++ b/symbols/shields/icn_9x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 30">
-  <rect x="0.5" y="0.5" width="64.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x2_z16.svg
+++ b/symbols/shields/icn_9x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 34">
-  <rect x="0.5" y="0.5" width="63.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x2_z18.svg
+++ b/symbols/shields/icn_9x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 36">
-  <rect x="0.5" y="0.5" width="71.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x3.svg
+++ b/symbols/shields/icn_9x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 42">
-  <rect x="0.5" y="0.5" width="64.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x3_z16.svg
+++ b/symbols/shields/icn_9x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 48">
-  <rect x="0.5" y="0.5" width="63.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x3_z18.svg
+++ b/symbols/shields/icn_9x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 51">
-  <rect x="0.5" y="0.5" width="71.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x4.svg
+++ b/symbols/shields/icn_9x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 54">
-  <rect x="0.5" y="0.5" width="64.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x4_z16.svg
+++ b/symbols/shields/icn_9x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 62">
-  <rect x="0.5" y="0.5" width="63.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/icn_9x4_z18.svg
+++ b/symbols/shields/icn_9x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 66">
-  <rect x="0.5" y="0.5" width="71.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#0b910b;stroke:#0b910b;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff00ff;stroke:#ff00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x1.svg
+++ b/symbols/shields/ncn_10x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 18">
-  <rect x="0.5" y="0.5" width="70.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x1_z16.svg
+++ b/symbols/shields/ncn_10x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 20">
-  <rect x="0.5" y="0.5" width="69.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x1_z18.svg
+++ b/symbols/shields/ncn_10x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 21">
-  <rect x="0.5" y="0.5" width="77.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x2.svg
+++ b/symbols/shields/ncn_10x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 30">
-  <rect x="0.5" y="0.5" width="70.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x2_z16.svg
+++ b/symbols/shields/ncn_10x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 34">
-  <rect x="0.5" y="0.5" width="69.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x2_z18.svg
+++ b/symbols/shields/ncn_10x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 36">
-  <rect x="0.5" y="0.5" width="77.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x3.svg
+++ b/symbols/shields/ncn_10x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 42">
-  <rect x="0.5" y="0.5" width="70.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x3_z16.svg
+++ b/symbols/shields/ncn_10x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 48">
-  <rect x="0.5" y="0.5" width="69.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x3_z18.svg
+++ b/symbols/shields/ncn_10x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 51">
-  <rect x="0.5" y="0.5" width="77.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x4.svg
+++ b/symbols/shields/ncn_10x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 54">
-  <rect x="0.5" y="0.5" width="70.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x4_z16.svg
+++ b/symbols/shields/ncn_10x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 62">
-  <rect x="0.5" y="0.5" width="69.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_10x4_z18.svg
+++ b/symbols/shields/ncn_10x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 66">
-  <rect x="0.5" y="0.5" width="77.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x1.svg
+++ b/symbols/shields/ncn_11x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 18">
-  <rect x="0.5" y="0.5" width="77.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x1_z16.svg
+++ b/symbols/shields/ncn_11x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 20">
-  <rect x="0.5" y="0.5" width="76.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x1_z18.svg
+++ b/symbols/shields/ncn_11x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 21">
-  <rect x="0.5" y="0.5" width="84.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x2.svg
+++ b/symbols/shields/ncn_11x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 30">
-  <rect x="0.5" y="0.5" width="77.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x2_z16.svg
+++ b/symbols/shields/ncn_11x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 34">
-  <rect x="0.5" y="0.5" width="76.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x2_z18.svg
+++ b/symbols/shields/ncn_11x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 36">
-  <rect x="0.5" y="0.5" width="84.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x3.svg
+++ b/symbols/shields/ncn_11x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 42">
-  <rect x="0.5" y="0.5" width="77.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x3_z16.svg
+++ b/symbols/shields/ncn_11x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 48">
-  <rect x="0.5" y="0.5" width="76.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x3_z18.svg
+++ b/symbols/shields/ncn_11x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 51">
-  <rect x="0.5" y="0.5" width="84.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x4.svg
+++ b/symbols/shields/ncn_11x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 54">
-  <rect x="0.5" y="0.5" width="77.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x4_z16.svg
+++ b/symbols/shields/ncn_11x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 62">
-  <rect x="0.5" y="0.5" width="76.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_11x4_z18.svg
+++ b/symbols/shields/ncn_11x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 66">
-  <rect x="0.5" y="0.5" width="84.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x1.svg
+++ b/symbols/shields/ncn_1x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 18">
-  <rect x="0.5" y="0.5" width="15.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x1_z16.svg
+++ b/symbols/shields/ncn_1x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 20">
-  <rect x="0.5" y="0.5" width="15.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x1_z18.svg
+++ b/symbols/shields/ncn_1x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 21">
-  <rect x="0.5" y="0.5" width="15.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x2.svg
+++ b/symbols/shields/ncn_1x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 30">
-  <rect x="0.5" y="0.5" width="15.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x2_z16.svg
+++ b/symbols/shields/ncn_1x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 34">
-  <rect x="0.5" y="0.5" width="15.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x2_z18.svg
+++ b/symbols/shields/ncn_1x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 36">
-  <rect x="0.5" y="0.5" width="15.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x3.svg
+++ b/symbols/shields/ncn_1x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 42">
-  <rect x="0.5" y="0.5" width="15.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x3_z16.svg
+++ b/symbols/shields/ncn_1x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 48">
-  <rect x="0.5" y="0.5" width="15.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x3_z18.svg
+++ b/symbols/shields/ncn_1x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 51">
-  <rect x="0.5" y="0.5" width="15.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x4.svg
+++ b/symbols/shields/ncn_1x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 54">
-  <rect x="0.5" y="0.5" width="15.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x4_z16.svg
+++ b/symbols/shields/ncn_1x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 62">
-  <rect x="0.5" y="0.5" width="15.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_1x4_z18.svg
+++ b/symbols/shields/ncn_1x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 66">
-  <rect x="0.5" y="0.5" width="15.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x1.svg
+++ b/symbols/shields/ncn_2x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 18">
-  <rect x="0.5" y="0.5" width="21.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x1_z16.svg
+++ b/symbols/shields/ncn_2x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 20">
-  <rect x="0.5" y="0.5" width="21.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x1_z18.svg
+++ b/symbols/shields/ncn_2x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 21">
-  <rect x="0.5" y="0.5" width="22.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x2.svg
+++ b/symbols/shields/ncn_2x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 30">
-  <rect x="0.5" y="0.5" width="21.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x2_z16.svg
+++ b/symbols/shields/ncn_2x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 34">
-  <rect x="0.5" y="0.5" width="21.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x2_z18.svg
+++ b/symbols/shields/ncn_2x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 36">
-  <rect x="0.5" y="0.5" width="22.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x3.svg
+++ b/symbols/shields/ncn_2x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 42">
-  <rect x="0.5" y="0.5" width="21.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x3_z16.svg
+++ b/symbols/shields/ncn_2x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 48">
-  <rect x="0.5" y="0.5" width="21.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x3_z18.svg
+++ b/symbols/shields/ncn_2x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 51">
-  <rect x="0.5" y="0.5" width="22.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x4.svg
+++ b/symbols/shields/ncn_2x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 54">
-  <rect x="0.5" y="0.5" width="21.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x4_z16.svg
+++ b/symbols/shields/ncn_2x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 62">
-  <rect x="0.5" y="0.5" width="21.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_2x4_z18.svg
+++ b/symbols/shields/ncn_2x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 66">
-  <rect x="0.5" y="0.5" width="22.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x1.svg
+++ b/symbols/shields/ncn_3x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 18">
-  <rect x="0.5" y="0.5" width="27.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x1_z16.svg
+++ b/symbols/shields/ncn_3x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 20">
-  <rect x="0.5" y="0.5" width="27.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x1_z18.svg
+++ b/symbols/shields/ncn_3x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 21">
-  <rect x="0.5" y="0.5" width="29.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x2.svg
+++ b/symbols/shields/ncn_3x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 30">
-  <rect x="0.5" y="0.5" width="27.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x2_z16.svg
+++ b/symbols/shields/ncn_3x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 34">
-  <rect x="0.5" y="0.5" width="27.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x2_z18.svg
+++ b/symbols/shields/ncn_3x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 36">
-  <rect x="0.5" y="0.5" width="29.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x3.svg
+++ b/symbols/shields/ncn_3x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 42">
-  <rect x="0.5" y="0.5" width="27.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x3_z16.svg
+++ b/symbols/shields/ncn_3x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 48">
-  <rect x="0.5" y="0.5" width="27.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x3_z18.svg
+++ b/symbols/shields/ncn_3x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 51">
-  <rect x="0.5" y="0.5" width="29.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x4.svg
+++ b/symbols/shields/ncn_3x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 54">
-  <rect x="0.5" y="0.5" width="27.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x4_z16.svg
+++ b/symbols/shields/ncn_3x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 62">
-  <rect x="0.5" y="0.5" width="27.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_3x4_z18.svg
+++ b/symbols/shields/ncn_3x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 66">
-  <rect x="0.5" y="0.5" width="29.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x1.svg
+++ b/symbols/shields/ncn_4x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 18">
-  <rect x="0.5" y="0.5" width="33.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x1_z16.svg
+++ b/symbols/shields/ncn_4x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 20">
-  <rect x="0.5" y="0.5" width="33.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x1_z18.svg
+++ b/symbols/shields/ncn_4x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 21">
-  <rect x="0.5" y="0.5" width="36.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x2.svg
+++ b/symbols/shields/ncn_4x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 30">
-  <rect x="0.5" y="0.5" width="33.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x2_z16.svg
+++ b/symbols/shields/ncn_4x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 34">
-  <rect x="0.5" y="0.5" width="33.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x2_z18.svg
+++ b/symbols/shields/ncn_4x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 36">
-  <rect x="0.5" y="0.5" width="36.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x3.svg
+++ b/symbols/shields/ncn_4x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 42">
-  <rect x="0.5" y="0.5" width="33.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x3_z16.svg
+++ b/symbols/shields/ncn_4x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 48">
-  <rect x="0.5" y="0.5" width="33.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x3_z18.svg
+++ b/symbols/shields/ncn_4x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 51">
-  <rect x="0.5" y="0.5" width="36.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x4.svg
+++ b/symbols/shields/ncn_4x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 54">
-  <rect x="0.5" y="0.5" width="33.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x4_z16.svg
+++ b/symbols/shields/ncn_4x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 62">
-  <rect x="0.5" y="0.5" width="33.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_4x4_z18.svg
+++ b/symbols/shields/ncn_4x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 66">
-  <rect x="0.5" y="0.5" width="36.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x1.svg
+++ b/symbols/shields/ncn_5x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 18">
-  <rect x="0.5" y="0.5" width="39.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x1_z16.svg
+++ b/symbols/shields/ncn_5x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 20">
-  <rect x="0.5" y="0.5" width="39.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x1_z18.svg
+++ b/symbols/shields/ncn_5x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 21">
-  <rect x="0.5" y="0.5" width="43.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x2.svg
+++ b/symbols/shields/ncn_5x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 30">
-  <rect x="0.5" y="0.5" width="39.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x2_z16.svg
+++ b/symbols/shields/ncn_5x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 34">
-  <rect x="0.5" y="0.5" width="39.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x2_z18.svg
+++ b/symbols/shields/ncn_5x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 36">
-  <rect x="0.5" y="0.5" width="43.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x3.svg
+++ b/symbols/shields/ncn_5x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 42">
-  <rect x="0.5" y="0.5" width="39.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x3_z16.svg
+++ b/symbols/shields/ncn_5x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 48">
-  <rect x="0.5" y="0.5" width="39.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x3_z18.svg
+++ b/symbols/shields/ncn_5x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 51">
-  <rect x="0.5" y="0.5" width="43.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x4.svg
+++ b/symbols/shields/ncn_5x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 54">
-  <rect x="0.5" y="0.5" width="39.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x4_z16.svg
+++ b/symbols/shields/ncn_5x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 62">
-  <rect x="0.5" y="0.5" width="39.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_5x4_z18.svg
+++ b/symbols/shields/ncn_5x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 66">
-  <rect x="0.5" y="0.5" width="43.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x1.svg
+++ b/symbols/shields/ncn_6x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 18">
-  <rect x="0.5" y="0.5" width="46.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x1_z16.svg
+++ b/symbols/shields/ncn_6x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 20">
-  <rect x="0.5" y="0.5" width="45.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x1_z18.svg
+++ b/symbols/shields/ncn_6x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 21">
-  <rect x="0.5" y="0.5" width="50.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x2.svg
+++ b/symbols/shields/ncn_6x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 30">
-  <rect x="0.5" y="0.5" width="46.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x2_z16.svg
+++ b/symbols/shields/ncn_6x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 34">
-  <rect x="0.5" y="0.5" width="45.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x2_z18.svg
+++ b/symbols/shields/ncn_6x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 36">
-  <rect x="0.5" y="0.5" width="50.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x3.svg
+++ b/symbols/shields/ncn_6x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 42">
-  <rect x="0.5" y="0.5" width="46.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x3_z16.svg
+++ b/symbols/shields/ncn_6x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 48">
-  <rect x="0.5" y="0.5" width="45.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x3_z18.svg
+++ b/symbols/shields/ncn_6x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 51">
-  <rect x="0.5" y="0.5" width="50.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x4.svg
+++ b/symbols/shields/ncn_6x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 54">
-  <rect x="0.5" y="0.5" width="46.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x4_z16.svg
+++ b/symbols/shields/ncn_6x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 62">
-  <rect x="0.5" y="0.5" width="45.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_6x4_z18.svg
+++ b/symbols/shields/ncn_6x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 66">
-  <rect x="0.5" y="0.5" width="50.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x1.svg
+++ b/symbols/shields/ncn_7x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 18">
-  <rect x="0.5" y="0.5" width="52.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x1_z16.svg
+++ b/symbols/shields/ncn_7x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 20">
-  <rect x="0.5" y="0.5" width="51.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x1_z18.svg
+++ b/symbols/shields/ncn_7x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 21">
-  <rect x="0.5" y="0.5" width="57.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x2.svg
+++ b/symbols/shields/ncn_7x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 30">
-  <rect x="0.5" y="0.5" width="52.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x2_z16.svg
+++ b/symbols/shields/ncn_7x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 34">
-  <rect x="0.5" y="0.5" width="51.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x2_z18.svg
+++ b/symbols/shields/ncn_7x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 36">
-  <rect x="0.5" y="0.5" width="57.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x3.svg
+++ b/symbols/shields/ncn_7x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 42">
-  <rect x="0.5" y="0.5" width="52.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x3_z16.svg
+++ b/symbols/shields/ncn_7x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 48">
-  <rect x="0.5" y="0.5" width="51.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x3_z18.svg
+++ b/symbols/shields/ncn_7x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 51">
-  <rect x="0.5" y="0.5" width="57.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x4.svg
+++ b/symbols/shields/ncn_7x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 54">
-  <rect x="0.5" y="0.5" width="52.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x4_z16.svg
+++ b/symbols/shields/ncn_7x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 62">
-  <rect x="0.5" y="0.5" width="51.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_7x4_z18.svg
+++ b/symbols/shields/ncn_7x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 66">
-  <rect x="0.5" y="0.5" width="57.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x1.svg
+++ b/symbols/shields/ncn_8x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 18">
-  <rect x="0.5" y="0.5" width="58.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x1_z16.svg
+++ b/symbols/shields/ncn_8x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 20">
-  <rect x="0.5" y="0.5" width="57.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x1_z18.svg
+++ b/symbols/shields/ncn_8x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 21">
-  <rect x="0.5" y="0.5" width="64.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x2.svg
+++ b/symbols/shields/ncn_8x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 30">
-  <rect x="0.5" y="0.5" width="58.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x2_z16.svg
+++ b/symbols/shields/ncn_8x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 34">
-  <rect x="0.5" y="0.5" width="57.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x2_z18.svg
+++ b/symbols/shields/ncn_8x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 36">
-  <rect x="0.5" y="0.5" width="64.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x3.svg
+++ b/symbols/shields/ncn_8x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 42">
-  <rect x="0.5" y="0.5" width="58.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x3_z16.svg
+++ b/symbols/shields/ncn_8x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 48">
-  <rect x="0.5" y="0.5" width="57.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x3_z18.svg
+++ b/symbols/shields/ncn_8x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 51">
-  <rect x="0.5" y="0.5" width="64.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x4.svg
+++ b/symbols/shields/ncn_8x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 54">
-  <rect x="0.5" y="0.5" width="58.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x4_z16.svg
+++ b/symbols/shields/ncn_8x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 62">
-  <rect x="0.5" y="0.5" width="57.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_8x4_z18.svg
+++ b/symbols/shields/ncn_8x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 66">
-  <rect x="0.5" y="0.5" width="64.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x1.svg
+++ b/symbols/shields/ncn_9x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 18">
-  <rect x="0.5" y="0.5" width="64.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x1_z16.svg
+++ b/symbols/shields/ncn_9x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 20">
-  <rect x="0.5" y="0.5" width="63.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x1_z18.svg
+++ b/symbols/shields/ncn_9x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 21">
-  <rect x="0.5" y="0.5" width="71.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x2.svg
+++ b/symbols/shields/ncn_9x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 30">
-  <rect x="0.5" y="0.5" width="64.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x2_z16.svg
+++ b/symbols/shields/ncn_9x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 34">
-  <rect x="0.5" y="0.5" width="63.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x2_z18.svg
+++ b/symbols/shields/ncn_9x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 36">
-  <rect x="0.5" y="0.5" width="71.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x3.svg
+++ b/symbols/shields/ncn_9x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 42">
-  <rect x="0.5" y="0.5" width="64.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x3_z16.svg
+++ b/symbols/shields/ncn_9x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 48">
-  <rect x="0.5" y="0.5" width="63.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x3_z18.svg
+++ b/symbols/shields/ncn_9x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 51">
-  <rect x="0.5" y="0.5" width="71.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x4.svg
+++ b/symbols/shields/ncn_9x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 54">
-  <rect x="0.5" y="0.5" width="64.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x4_z16.svg
+++ b/symbols/shields/ncn_9x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 62">
-  <rect x="0.5" y="0.5" width="63.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/ncn_9x4_z18.svg
+++ b/symbols/shields/ncn_9x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 66">
-  <rect x="0.5" y="0.5" width="71.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#ff0000;stroke:#ff0000;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#aa00ff;stroke:#aa00ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x1.svg
+++ b/symbols/shields/rcn_10x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 18">
-  <rect x="0.5" y="0.5" width="70.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x1_z16.svg
+++ b/symbols/shields/rcn_10x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 20">
-  <rect x="0.5" y="0.5" width="69.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x1_z18.svg
+++ b/symbols/shields/rcn_10x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 21">
-  <rect x="0.5" y="0.5" width="77.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x2.svg
+++ b/symbols/shields/rcn_10x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 30">
-  <rect x="0.5" y="0.5" width="70.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x2_z16.svg
+++ b/symbols/shields/rcn_10x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 34">
-  <rect x="0.5" y="0.5" width="69.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x2_z18.svg
+++ b/symbols/shields/rcn_10x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 36">
-  <rect x="0.5" y="0.5" width="77.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x3.svg
+++ b/symbols/shields/rcn_10x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 42">
-  <rect x="0.5" y="0.5" width="70.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x3_z16.svg
+++ b/symbols/shields/rcn_10x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 48">
-  <rect x="0.5" y="0.5" width="69.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x3_z18.svg
+++ b/symbols/shields/rcn_10x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 51">
-  <rect x="0.5" y="0.5" width="77.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x4.svg
+++ b/symbols/shields/rcn_10x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 71 54">
-  <rect x="0.5" y="0.5" width="70.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="70.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x4_z16.svg
+++ b/symbols/shields/rcn_10x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 70 62">
-  <rect x="0.5" y="0.5" width="69.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="69.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_10x4_z18.svg
+++ b/symbols/shields/rcn_10x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 66">
-  <rect x="0.5" y="0.5" width="77.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x1.svg
+++ b/symbols/shields/rcn_11x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 18">
-  <rect x="0.5" y="0.5" width="77.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x1_z16.svg
+++ b/symbols/shields/rcn_11x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 20">
-  <rect x="0.5" y="0.5" width="76.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x1_z18.svg
+++ b/symbols/shields/rcn_11x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 21">
-  <rect x="0.5" y="0.5" width="84.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x2.svg
+++ b/symbols/shields/rcn_11x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 30">
-  <rect x="0.5" y="0.5" width="77.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x2_z16.svg
+++ b/symbols/shields/rcn_11x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 34">
-  <rect x="0.5" y="0.5" width="76.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x2_z18.svg
+++ b/symbols/shields/rcn_11x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 36">
-  <rect x="0.5" y="0.5" width="84.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x3.svg
+++ b/symbols/shields/rcn_11x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 42">
-  <rect x="0.5" y="0.5" width="77.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x3_z16.svg
+++ b/symbols/shields/rcn_11x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 48">
-  <rect x="0.5" y="0.5" width="76.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x3_z18.svg
+++ b/symbols/shields/rcn_11x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 51">
-  <rect x="0.5" y="0.5" width="84.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x4.svg
+++ b/symbols/shields/rcn_11x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 78 54">
-  <rect x="0.5" y="0.5" width="77.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="77.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x4_z16.svg
+++ b/symbols/shields/rcn_11x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 77 62">
-  <rect x="0.5" y="0.5" width="76.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="76.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_11x4_z18.svg
+++ b/symbols/shields/rcn_11x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 85 66">
-  <rect x="0.5" y="0.5" width="84.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="84.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x1.svg
+++ b/symbols/shields/rcn_1x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 18">
-  <rect x="0.5" y="0.5" width="15.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x1_z16.svg
+++ b/symbols/shields/rcn_1x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 20">
-  <rect x="0.5" y="0.5" width="15.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x1_z18.svg
+++ b/symbols/shields/rcn_1x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 21">
-  <rect x="0.5" y="0.5" width="15.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x2.svg
+++ b/symbols/shields/rcn_1x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 30">
-  <rect x="0.5" y="0.5" width="15.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x2_z16.svg
+++ b/symbols/shields/rcn_1x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 34">
-  <rect x="0.5" y="0.5" width="15.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x2_z18.svg
+++ b/symbols/shields/rcn_1x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 36">
-  <rect x="0.5" y="0.5" width="15.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x3.svg
+++ b/symbols/shields/rcn_1x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 42">
-  <rect x="0.5" y="0.5" width="15.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x3_z16.svg
+++ b/symbols/shields/rcn_1x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 48">
-  <rect x="0.5" y="0.5" width="15.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x3_z18.svg
+++ b/symbols/shields/rcn_1x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 51">
-  <rect x="0.5" y="0.5" width="15.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x4.svg
+++ b/symbols/shields/rcn_1x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 54">
-  <rect x="0.5" y="0.5" width="15.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x4_z16.svg
+++ b/symbols/shields/rcn_1x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 62">
-  <rect x="0.5" y="0.5" width="15.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_1x4_z18.svg
+++ b/symbols/shields/rcn_1x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 16 66">
-  <rect x="0.5" y="0.5" width="15.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="15.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x1.svg
+++ b/symbols/shields/rcn_2x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 18">
-  <rect x="0.5" y="0.5" width="21.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x1_z16.svg
+++ b/symbols/shields/rcn_2x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 20">
-  <rect x="0.5" y="0.5" width="21.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x1_z18.svg
+++ b/symbols/shields/rcn_2x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 21">
-  <rect x="0.5" y="0.5" width="22.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x2.svg
+++ b/symbols/shields/rcn_2x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 30">
-  <rect x="0.5" y="0.5" width="21.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x2_z16.svg
+++ b/symbols/shields/rcn_2x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 34">
-  <rect x="0.5" y="0.5" width="21.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x2_z18.svg
+++ b/symbols/shields/rcn_2x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 36">
-  <rect x="0.5" y="0.5" width="22.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x3.svg
+++ b/symbols/shields/rcn_2x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 42">
-  <rect x="0.5" y="0.5" width="21.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x3_z16.svg
+++ b/symbols/shields/rcn_2x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 48">
-  <rect x="0.5" y="0.5" width="21.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x3_z18.svg
+++ b/symbols/shields/rcn_2x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 51">
-  <rect x="0.5" y="0.5" width="22.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x4.svg
+++ b/symbols/shields/rcn_2x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 54">
-  <rect x="0.5" y="0.5" width="21.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x4_z16.svg
+++ b/symbols/shields/rcn_2x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 22 62">
-  <rect x="0.5" y="0.5" width="21.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="21.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_2x4_z18.svg
+++ b/symbols/shields/rcn_2x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 23 66">
-  <rect x="0.5" y="0.5" width="22.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="22.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x1.svg
+++ b/symbols/shields/rcn_3x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 18">
-  <rect x="0.5" y="0.5" width="27.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x1_z16.svg
+++ b/symbols/shields/rcn_3x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 20">
-  <rect x="0.5" y="0.5" width="27.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x1_z18.svg
+++ b/symbols/shields/rcn_3x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 21">
-  <rect x="0.5" y="0.5" width="29.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x2.svg
+++ b/symbols/shields/rcn_3x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 30">
-  <rect x="0.5" y="0.5" width="27.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x2_z16.svg
+++ b/symbols/shields/rcn_3x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 34">
-  <rect x="0.5" y="0.5" width="27.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x2_z18.svg
+++ b/symbols/shields/rcn_3x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 36">
-  <rect x="0.5" y="0.5" width="29.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x3.svg
+++ b/symbols/shields/rcn_3x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 42">
-  <rect x="0.5" y="0.5" width="27.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x3_z16.svg
+++ b/symbols/shields/rcn_3x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 48">
-  <rect x="0.5" y="0.5" width="27.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x3_z18.svg
+++ b/symbols/shields/rcn_3x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 51">
-  <rect x="0.5" y="0.5" width="29.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x4.svg
+++ b/symbols/shields/rcn_3x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 54">
-  <rect x="0.5" y="0.5" width="27.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x4_z16.svg
+++ b/symbols/shields/rcn_3x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 28 62">
-  <rect x="0.5" y="0.5" width="27.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="27.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_3x4_z18.svg
+++ b/symbols/shields/rcn_3x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 30 66">
-  <rect x="0.5" y="0.5" width="29.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="29.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x1.svg
+++ b/symbols/shields/rcn_4x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 18">
-  <rect x="0.5" y="0.5" width="33.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x1_z16.svg
+++ b/symbols/shields/rcn_4x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 20">
-  <rect x="0.5" y="0.5" width="33.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x1_z18.svg
+++ b/symbols/shields/rcn_4x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 21">
-  <rect x="0.5" y="0.5" width="36.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x2.svg
+++ b/symbols/shields/rcn_4x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 30">
-  <rect x="0.5" y="0.5" width="33.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x2_z16.svg
+++ b/symbols/shields/rcn_4x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 34">
-  <rect x="0.5" y="0.5" width="33.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x2_z18.svg
+++ b/symbols/shields/rcn_4x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 36">
-  <rect x="0.5" y="0.5" width="36.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x3.svg
+++ b/symbols/shields/rcn_4x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 42">
-  <rect x="0.5" y="0.5" width="33.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x3_z16.svg
+++ b/symbols/shields/rcn_4x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 48">
-  <rect x="0.5" y="0.5" width="33.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x3_z18.svg
+++ b/symbols/shields/rcn_4x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 51">
-  <rect x="0.5" y="0.5" width="36.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x4.svg
+++ b/symbols/shields/rcn_4x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 54">
-  <rect x="0.5" y="0.5" width="33.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x4_z16.svg
+++ b/symbols/shields/rcn_4x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 34 62">
-  <rect x="0.5" y="0.5" width="33.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="33.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_4x4_z18.svg
+++ b/symbols/shields/rcn_4x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 37 66">
-  <rect x="0.5" y="0.5" width="36.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="36.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x1.svg
+++ b/symbols/shields/rcn_5x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 18">
-  <rect x="0.5" y="0.5" width="39.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x1_z16.svg
+++ b/symbols/shields/rcn_5x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 20">
-  <rect x="0.5" y="0.5" width="39.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x1_z18.svg
+++ b/symbols/shields/rcn_5x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 21">
-  <rect x="0.5" y="0.5" width="43.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x2.svg
+++ b/symbols/shields/rcn_5x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 30">
-  <rect x="0.5" y="0.5" width="39.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x2_z16.svg
+++ b/symbols/shields/rcn_5x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 34">
-  <rect x="0.5" y="0.5" width="39.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x2_z18.svg
+++ b/symbols/shields/rcn_5x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 36">
-  <rect x="0.5" y="0.5" width="43.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x3.svg
+++ b/symbols/shields/rcn_5x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 42">
-  <rect x="0.5" y="0.5" width="39.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x3_z16.svg
+++ b/symbols/shields/rcn_5x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 48">
-  <rect x="0.5" y="0.5" width="39.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x3_z18.svg
+++ b/symbols/shields/rcn_5x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 51">
-  <rect x="0.5" y="0.5" width="43.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x4.svg
+++ b/symbols/shields/rcn_5x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 54">
-  <rect x="0.5" y="0.5" width="39.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x4_z16.svg
+++ b/symbols/shields/rcn_5x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 40 62">
-  <rect x="0.5" y="0.5" width="39.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="39.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_5x4_z18.svg
+++ b/symbols/shields/rcn_5x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 44 66">
-  <rect x="0.5" y="0.5" width="43.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="43.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x1.svg
+++ b/symbols/shields/rcn_6x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 18">
-  <rect x="0.5" y="0.5" width="46.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x1_z16.svg
+++ b/symbols/shields/rcn_6x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 20">
-  <rect x="0.5" y="0.5" width="45.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x1_z18.svg
+++ b/symbols/shields/rcn_6x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 21">
-  <rect x="0.5" y="0.5" width="50.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x2.svg
+++ b/symbols/shields/rcn_6x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 30">
-  <rect x="0.5" y="0.5" width="46.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x2_z16.svg
+++ b/symbols/shields/rcn_6x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 34">
-  <rect x="0.5" y="0.5" width="45.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x2_z18.svg
+++ b/symbols/shields/rcn_6x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 36">
-  <rect x="0.5" y="0.5" width="50.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x3.svg
+++ b/symbols/shields/rcn_6x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 42">
-  <rect x="0.5" y="0.5" width="46.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x3_z16.svg
+++ b/symbols/shields/rcn_6x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 48">
-  <rect x="0.5" y="0.5" width="45.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x3_z18.svg
+++ b/symbols/shields/rcn_6x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 51">
-  <rect x="0.5" y="0.5" width="50.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x4.svg
+++ b/symbols/shields/rcn_6x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 47 54">
-  <rect x="0.5" y="0.5" width="46.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="46.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x4_z16.svg
+++ b/symbols/shields/rcn_6x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 46 62">
-  <rect x="0.5" y="0.5" width="45.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="45.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_6x4_z18.svg
+++ b/symbols/shields/rcn_6x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 51 66">
-  <rect x="0.5" y="0.5" width="50.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="50.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x1.svg
+++ b/symbols/shields/rcn_7x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 18">
-  <rect x="0.5" y="0.5" width="52.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x1_z16.svg
+++ b/symbols/shields/rcn_7x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 20">
-  <rect x="0.5" y="0.5" width="51.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x1_z18.svg
+++ b/symbols/shields/rcn_7x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 21">
-  <rect x="0.5" y="0.5" width="57.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x2.svg
+++ b/symbols/shields/rcn_7x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 30">
-  <rect x="0.5" y="0.5" width="52.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x2_z16.svg
+++ b/symbols/shields/rcn_7x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 34">
-  <rect x="0.5" y="0.5" width="51.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x2_z18.svg
+++ b/symbols/shields/rcn_7x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 36">
-  <rect x="0.5" y="0.5" width="57.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x3.svg
+++ b/symbols/shields/rcn_7x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 42">
-  <rect x="0.5" y="0.5" width="52.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x3_z16.svg
+++ b/symbols/shields/rcn_7x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 48">
-  <rect x="0.5" y="0.5" width="51.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x3_z18.svg
+++ b/symbols/shields/rcn_7x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 51">
-  <rect x="0.5" y="0.5" width="57.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x4.svg
+++ b/symbols/shields/rcn_7x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 53 54">
-  <rect x="0.5" y="0.5" width="52.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="52.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x4_z16.svg
+++ b/symbols/shields/rcn_7x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 52 62">
-  <rect x="0.5" y="0.5" width="51.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="51.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_7x4_z18.svg
+++ b/symbols/shields/rcn_7x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 66">
-  <rect x="0.5" y="0.5" width="57.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x1.svg
+++ b/symbols/shields/rcn_8x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 18">
-  <rect x="0.5" y="0.5" width="58.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x1_z16.svg
+++ b/symbols/shields/rcn_8x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 20">
-  <rect x="0.5" y="0.5" width="57.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x1_z18.svg
+++ b/symbols/shields/rcn_8x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 21">
-  <rect x="0.5" y="0.5" width="64.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x2.svg
+++ b/symbols/shields/rcn_8x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 30">
-  <rect x="0.5" y="0.5" width="58.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x2_z16.svg
+++ b/symbols/shields/rcn_8x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 34">
-  <rect x="0.5" y="0.5" width="57.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x2_z18.svg
+++ b/symbols/shields/rcn_8x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 36">
-  <rect x="0.5" y="0.5" width="64.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x3.svg
+++ b/symbols/shields/rcn_8x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 42">
-  <rect x="0.5" y="0.5" width="58.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x3_z16.svg
+++ b/symbols/shields/rcn_8x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 48">
-  <rect x="0.5" y="0.5" width="57.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x3_z18.svg
+++ b/symbols/shields/rcn_8x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 51">
-  <rect x="0.5" y="0.5" width="64.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x4.svg
+++ b/symbols/shields/rcn_8x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 59 54">
-  <rect x="0.5" y="0.5" width="58.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="58.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x4_z16.svg
+++ b/symbols/shields/rcn_8x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 58 62">
-  <rect x="0.5" y="0.5" width="57.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="57.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_8x4_z18.svg
+++ b/symbols/shields/rcn_8x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 66">
-  <rect x="0.5" y="0.5" width="64.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x1.svg
+++ b/symbols/shields/rcn_9x1.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 18">
-  <rect x="0.5" y="0.5" width="64.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="17.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x1_z16.svg
+++ b/symbols/shields/rcn_9x1_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 20">
-  <rect x="0.5" y="0.5" width="63.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="19.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x1_z18.svg
+++ b/symbols/shields/rcn_9x1_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 21">
-  <rect x="0.5" y="0.5" width="71.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="20.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x2.svg
+++ b/symbols/shields/rcn_9x2.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 30">
-  <rect x="0.5" y="0.5" width="64.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="29.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x2_z16.svg
+++ b/symbols/shields/rcn_9x2_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 34">
-  <rect x="0.5" y="0.5" width="63.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="33.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x2_z18.svg
+++ b/symbols/shields/rcn_9x2_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 36">
-  <rect x="0.5" y="0.5" width="71.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="35.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x3.svg
+++ b/symbols/shields/rcn_9x3.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 42">
-  <rect x="0.5" y="0.5" width="64.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="41.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x3_z16.svg
+++ b/symbols/shields/rcn_9x3_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 48">
-  <rect x="0.5" y="0.5" width="63.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="47.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x3_z18.svg
+++ b/symbols/shields/rcn_9x3_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 51">
-  <rect x="0.5" y="0.5" width="71.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="50.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x4.svg
+++ b/symbols/shields/rcn_9x4.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 65 54">
-  <rect x="0.5" y="0.5" width="64.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="64.0" height="53.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x4_z16.svg
+++ b/symbols/shields/rcn_9x4_z16.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 64 62">
-  <rect x="0.5" y="0.5" width="63.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="63.0" height="61.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>

--- a/symbols/shields/rcn_9x4_z18.svg
+++ b/symbols/shields/rcn_9x4_z18.svg
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='utf-8'?>
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 72 66">
-  <rect x="0.5" y="0.5" width="71.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#b42dff;stroke:#b42dff;stroke-width:1;"/>
+  <rect x="0.5" y="0.5" width="71.0" height="65.0" rx="2" ry="2" id="shield" style="fill:#5500ff;stroke:#5500ff;stroke-width:1;"/>
 </svg>


### PR DESCRIPTION
Cycle routes have 4 colors from Blue (LCN) to Purple (ICN), so mixing them by overlay will not create bad colors (brown for instance) but will stay between blue and purple.

![cyclosm_color_paths_color_cycleroutes](https://user-images.githubusercontent.com/47089717/53305236-3902d600-387f-11e9-8b89-39e7365da0e2.png)
