### PR TITLE
Oneway arrow should be grey when oneway for all vehicles. Fix #101

### DIFF
--- a/labels.mss
+++ b/labels.mss
@@ -533,7 +533,7 @@
      marker-max-error: 0.5;
      marker-spacing: 100;
      marker-fill: #777777;
-     [oneway_bicycle = 'yes'] {
+     [oneway != 'yes'][oneway_bicycle = 'yes'] {
        marker-fill: #00f;
      }
      [highway='cycleway'] {


### PR DESCRIPTION
Should fix https://github.com/cyclosm/cyclosm-cartocss-style/issues/101.

@Florimondable I'd need a double check on this one :)