### PR TITLE
Render cyclestreet=yes as a 20km/h street.

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -347,6 +347,7 @@ Layer:
       (
         SELECT way, COALESCE(highway, CASE WHEN railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'railway' ELSE 'other' END) AS type, 0 AS bridge, access, layer, 1 as tunnel,
           CASE
+            WHEN tags->'cyclestreet'='yes' THEN 20 -- render cyclestreets as maxspeed 20km/h
             WHEN tags->'maxspeed'~E'^\\d+$' THEN (tags->'maxspeed')::integer
             WHEN tags->'maxspeed'~E'^\\d+ mph$' THEN REPLACE(tags->'maxspeed', ' mph', '')::integer * 1.609344
             WHEN tags->'maxspeed'~E'^\\d+ knots$' THEN REPLACE(tags->'maxspeed', ' knots', '')::integer * 1.852
@@ -414,6 +415,7 @@ Layer:
       (
         SELECT way, COALESCE(highway, CASE WHEN railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'railway' ELSE 'other' END) AS type, 0 AS tunnel, 0 AS bridge, access,
           CASE
+            WHEN tags->'cyclestreet'='yes' THEN 20 -- render cyclestreets as maxspeed 20km/h
             WHEN tags->'maxspeed'~E'^\\d+$' THEN (tags->'maxspeed')::integer
             WHEN tags->'maxspeed'~E'^\\d+ mph$' THEN REPLACE(tags->'maxspeed', ' mph', '')::integer * 1.609344
             WHEN tags->'maxspeed'~E'^\\d+ knots$' THEN REPLACE(tags->'maxspeed', ' knots', '')::integer * 1.852
@@ -515,6 +517,7 @@ Layer:
       (
         SELECT way, COALESCE(highway, CASE WHEN railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'railway' ELSE 'other' END) AS type, 1 AS bridge, access, layer, 0 as tunnel,
           CASE
+            WHEN tags->'cyclestreet'='yes' THEN 20 -- render cyclestreets as maxspeed 20km/h
             WHEN tags->'maxspeed'~E'^\\d+$' THEN (tags->'maxspeed')::integer
             WHEN tags->'maxspeed'~E'^\\d+ mph$' THEN REPLACE(tags->'maxspeed', ' mph', '')::integer * 1.609344
             WHEN tags->'maxspeed'~E'^\\d+ knots$' THEN REPLACE(tags->'maxspeed', ' knots', '')::integer * 1.852


### PR DESCRIPTION
What do you think about rendering them as 20km/h streets?

In Belgium for instance, they are limited to 30km/h, but given that cars should behave as guests and bicycles should be the main users, I guess rendering them as 20km/h streets (which is an average speed for a typical bike) is fine.

I don't know this infrastructure very well, but it seems there is not much added benefits from a cycle street rather than a regular (well done) 20km/h limitation, isn't it?

The Bicycle tag map renders them as pink streets, but this cannot apply to us as pink is already in use for the bicycle routes.