### PR TITLE
Motorcycle-Bicycle parking in mixed blue

### DIFF
--- a/amenities.mss
+++ b/amenities.mss
@@ -773,6 +773,9 @@
       text-placements: "S,N,E,W,NE,SE,NW,SW";
       text-dy: 6;
       text-dx: 6;
+      [access != ''][access != 'permissive'][access != 'yes'] {
+        text-opacity: 0.33;
+      }
     }
   }
 

--- a/palette.mss
+++ b/palette.mss
@@ -167,7 +167,7 @@
 @bicycle_parking_fill: 	#0000ff;
 @motorcycle_parking_line:  #fff;
 @secured_motorcycle_parking_line: @secured_bicycle_parking_line;
-@motorcycle_parking_fill:  #ff0000;
+@motorcycle_parking_fill:  #0050ff;
 
 @natural_volcano: #980000;
 


### PR DESCRIPTION
Fix #177 

Fix also a bug with the text not drawn with full opacity whereas the parking circle is transparent cause of limited actess.

Motorcycle-bicycle parking on the left
![Capture du 2019-10-05 21-38-38](https://user-images.githubusercontent.com/47089717/66260011-25c2cc00-e7b9-11e9-88c2-cd20ceab3b1a.png)

Text bug
![Capture du 2019-10-05 21-42-12](https://user-images.githubusercontent.com/47089717/66260012-28bdbc80-e7b9-11e9-92ff-12ab0558c9ac.png)
Text fixed
![Capture du 2019-10-05 21-37-55](https://user-images.githubusercontent.com/47089717/66260014-29eee980-e7b9-11e9-806e-76822bf117d9.png)
