### PR TITLE
Make military areas visible even when both military and landuse are set

### DIFF
--- a/base.mss
+++ b/base.mss
@@ -138,7 +138,7 @@
   }
 }
 
-#protected-areas[zoom >=7 ] {
+#protected-areas[zoom >= 7] {
   line-color: darken(@wooded,25%);
   line-opacity:  0.3;
   line-dasharray: 1,1;
@@ -152,18 +152,17 @@
   [zoom>=12] { line-width: 2.0; }
 }
 
-#military-overlay[type = 'military'][zoom >= 8][way_pixels > 900],
-#military-overlay[type = 'military'][zoom >= 13],
-#military-overlay[type = 'danger_area'][zoom >= 9] {
-  polygon-pattern-file: url('symbols/openstreetmap-carto/military_red_hatch.png');
+#military-overlay[landuse = 'military'][zoom >= 8][way_pixels > 900],
+#military-overlay[landuse = 'military'][zoom >= 13],
+#military-overlay[military = 'danger_area'][zoom >= 9] {
+  polygon-pattern-file: url('symbols/openstreetmap-carto/danger_red_hatch.png');
   polygon-pattern-alignment: global;
   line-color: @military;
   line-opacity: 0.24;
   line-width: 1.0;
   line-offset: -0.5;
   [zoom >= 15] {
-    [type = 'danger_area'] {
-      polygon-pattern-file: url('symbols/openstreetmap-carto/danger_red_hatch.png');
+    [military = 'danger_area'] {
       line-opacity: 0.2;
     }
     line-width: 2;

--- a/project.mml
+++ b/project.mml
@@ -2278,7 +2278,8 @@ Layer:
       (
         SELECT
           way,
-          COALESCE(military, landuse) AS type,
+          landuse,
+          military,
           way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels
         FROM planet_osm_polygon
         WHERE


### PR DESCRIPTION
Fixes https://github.com/cyclosm/cyclosm-cartocss-style/issues/270

The query missed military areas where both `military=...` and `landuse=military` are set. For example a military range with `landuse=military` and `military=range`. This feature would be picked up by the query, but not be styled on the map.

Example query for such data: https://overpass-turbo.eu/s/PSG

Before:

![Annotation 2020-01-18 213654](https://user-images.githubusercontent.com/1073881/72670873-2cf9a700-3a43-11ea-806b-ff1f07a0f23a.png)

After

![Annotation 2020-01-18 223200](https://user-images.githubusercontent.com/1073881/72670874-2d923d80-3a43-11ea-8ef5-4a2340b7f24b.png)
