### PR TITLE
Do not show regional cycling network routes on zoom 8-10

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -954,6 +954,7 @@ Layer:
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network' IN ('icn', 'ncn', 'rcn')
+          AND NOT (tags->'network' = 'rcn' AND tags->'network:type' = 'node_network')
         ORDER BY CASE
           WHEN tags->'network' = 'icn' THEN 0
           WHEN tags->'network' = 'ncn' THEN 1
@@ -1318,9 +1319,11 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT way, route, tags->'network'AS type, ref, 1 as height, char_length(ref) AS width
+        SELECT way, route, tags->'network' AS type, ref, 1 as height, char_length(ref) AS width
         FROM planet_osm_line
-        WHERE (route='bicycle' OR route='mtb') AND ref IS NOT NULL
+        WHERE (route = 'bicycle' OR route = 'mtb')
+          AND ref IS NOT NULL
+          AND NOT (tags->'network' = 'rcn' AND tags->'network:type' = 'node_network')
       ) AS data
   geometry: linestring
   properties:


### PR DESCRIPTION
This PR improves the cycling network visualization in The Netherlands and Belgium for any regional routes marked with `network:type = 'node_network'` (impact, see https://taginfo.openstreetmap.org/tags/network%3Atype=node_network#map)

Large improvement for issue #276.

- Don't include cycling network regional routes (node network type) for display on zoom levels 8 to 10
- Don't show cycling network regional routes (node network type) labels on any zoom level (the route names are not important, the nodes are).

## Zoom 8

Old 

![image](https://user-images.githubusercontent.com/1073881/72683369-071de200-3ad7-11ea-9d92-d000f57d0e4a.png)

New 

![image](https://user-images.githubusercontent.com/1073881/72683340-d0e06280-3ad6-11ea-9987-84d8e6c76fa5.png)

## Zoom 10

Old 

![image](https://user-images.githubusercontent.com/1073881/72683378-1866ee80-3ad7-11ea-9862-68d74a4a6fe7.png)


New 

![image](https://user-images.githubusercontent.com/1073881/72683376-16049480-3ad7-11ea-973c-8444c7738a36.png)


## Zoom 11

Unchanged (except for the labels)

![image](https://user-images.githubusercontent.com/1073881/72683375-11d87700-3ad7-11ea-8925-f6f78ce53870.png)

