### PR TITLE
Fix null in 'not' in cycle route node query for zoom 8-10

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -977,7 +977,7 @@ Layer:
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network' IN ('icn', 'ncn', 'rcn')
-          AND NOT (tags->'network' = 'rcn' AND tags->'network:type' = 'node_network')
+          AND (NOT (tags->'network' = 'rcn' AND tags->'network:type' = 'node_network'))
           AND way && !bbox!
         ORDER BY CASE
           WHEN tags->'network' = 'icn' THEN 0
@@ -1347,7 +1347,7 @@ Layer:
         FROM planet_osm_line
         WHERE (route = 'bicycle' OR route = 'mtb')
           AND ref IS NOT NULL
-          AND NOT (tags->'network' = 'rcn' AND tags->'network:type' = 'node_network')
+          AND (NOT (tags->'network' = 'rcn' AND tags->'network:type' = 'node_network'))
       ) AS data
   geometry: linestring
   properties:

--- a/project.mml
+++ b/project.mml
@@ -977,7 +977,7 @@ Layer:
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network' IN ('icn', 'ncn', 'rcn')
-          AND (NOT (tags->'network' = 'rcn' AND tags->'network:type' = 'node_network'))
+          AND NOT ((tags->'network') IS NOT NULL AND (tags->'network:type') IS NOT NULL AND (tags->'network' = 'rcn') AND tags->'network:type' = 'node_network')
           AND way && !bbox!
         ORDER BY CASE
           WHEN tags->'network' = 'icn' THEN 0
@@ -1347,7 +1347,7 @@ Layer:
         FROM planet_osm_line
         WHERE (route = 'bicycle' OR route = 'mtb')
           AND ref IS NOT NULL
-          AND (NOT (tags->'network' = 'rcn' AND tags->'network:type' = 'node_network'))
+          AND NOT ((tags->'network') IS NOT NULL AND (tags->'network:type') IS NOT NULL AND (tags->'network' = 'rcn') AND tags->'network:type' = 'node_network')
       ) AS data
   geometry: linestring
   properties:

--- a/project.mml
+++ b/project.mml
@@ -977,7 +977,7 @@ Layer:
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network' IN ('icn', 'ncn', 'rcn')
-          AND NOT ((tags->'network') IS NOT NULL AND (tags->'network:type') IS NOT NULL AND (tags->'network' = 'rcn') AND tags->'network:type' = 'node_network')
+          AND (NOT ((tags->'network') IS NOT NULL AND (tags->'network:type') IS NOT NULL AND (tags->'network' = 'rcn') AND tags->'network:type' = 'node_network'))
           AND way && !bbox!
         ORDER BY CASE
           WHEN tags->'network' = 'icn' THEN 0
@@ -1347,7 +1347,7 @@ Layer:
         FROM planet_osm_line
         WHERE (route = 'bicycle' OR route = 'mtb')
           AND ref IS NOT NULL
-          AND NOT ((tags->'network') IS NOT NULL AND (tags->'network:type') IS NOT NULL AND (tags->'network' = 'rcn') AND tags->'network:type' = 'node_network')
+          AND (NOT ((tags->'network') IS NOT NULL AND (tags->'network:type') IS NOT NULL AND (tags->'network' = 'rcn') AND tags->'network:type' = 'node_network'))
       ) AS data
   geometry: linestring
   properties:


### PR DESCRIPTION
Fix #297.

There were null values in the query because not all ways have the tags in the query (of course...). And `null` is not `false` in SQL, but resolves the whole WHERE to `null`.

### Current live map

Zoom 8

![image](https://user-images.githubusercontent.com/1073881/73981999-be1db880-4933-11ea-9826-c1affed3c5ee.png)


Zoom 10

![image](https://user-images.githubusercontent.com/1073881/73982006-c1b13f80-4933-11ea-85b1-c3ffb56818c5.png)

### After fix

Zoom 8


![image](https://user-images.githubusercontent.com/1073881/73982826-4d779b80-4935-11ea-832a-867a86511fa7.png)


Zoom 10 


![image](https://user-images.githubusercontent.com/1073881/73982637-e954d780-4934-11ea-97cf-12b41f58acfa.png)
