### PR TITLE
Try to fix noise bicycle route at low zooms

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -936,7 +936,7 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT ST_Snaptogrid(way, !pixel_width! / 4) AS way, route, tags->'network' AS type, tags->'state' AS state
+        SELECT ST_Snaptogrid(way, !pixel_width! / 1024) AS way, route, tags->'network' AS type, tags->'state' AS state
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network'='icn'
@@ -953,7 +953,7 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT ST_Snaptogrid(way, !pixel_width! / 4) AS way, route, tags->'network' AS type, tags->'state' AS state
+        SELECT ST_Snaptogrid(way, !pixel_width! / 256) AS way, route, tags->'network' AS type, tags->'state' AS state
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network' IN ('icn', 'ncn')
@@ -973,7 +973,7 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT ST_Snaptogrid(way, !pixel_width! / 4) AS way, route, tags->'network' AS type, tags->'state' AS state
+        SELECT ST_Snaptogrid(way, !pixel_width! / 64) AS way, route, tags->'network' AS type, tags->'state' AS state
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network' IN ('icn', 'ncn', 'rcn')

--- a/project.mml
+++ b/project.mml
@@ -936,7 +936,7 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT ST_Snaptogrid(way, !pixel_width! / 1024) AS way, route, tags->'network' AS type, tags->'state' AS state
+        SELECT ST_Simplify(way, !pixel_width!/4, TRUE) AS way, route, tags->'network' AS type, tags->'state' AS state
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network'='icn'
@@ -953,7 +953,7 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT ST_Snaptogrid(way, !pixel_width! / 256) AS way, route, tags->'network' AS type, tags->'state' AS state
+        SELECT ST_Simplify(way, !pixel_width!/4, TRUE) AS way, route, tags->'network' AS type, tags->'state' AS state
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network' IN ('icn', 'ncn')
@@ -973,7 +973,7 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT ST_Snaptogrid(way, !pixel_width! / 64) AS way, route, tags->'network' AS type, tags->'state' AS state
+        SELECT ST_Simplify(way, !pixel_width!/4, TRUE) AS way, route, tags->'network' AS type, tags->'state' AS state
         FROM planet_osm_line
         WHERE (route='bicycle' OR route='mtb')
           AND tags->'network' IN ('icn', 'ncn', 'rcn')


### PR DESCRIPTION
to #253 

First commit use smaller grid to avoid its bad effect of filling the grid even if there is only one node in it Which result in noisy pixels around the route and like the opposite effect of antialiasing, that make the route more aliased and bigger. Results are ok.

Second commit use of ST_Symplify in order to realy simply the geometry which result with less nodes on the ways and hence better line rendering not aliased. Good result.

_Performance has not been tested, I don't know how to do that._

Before:
![Capture du 2020-02-11 23-43-15_snap4](https://user-images.githubusercontent.com/47089717/74287188-a70f0a00-4d29-11ea-8aa4-1e08a76e0797.png)

SnapToGrid after first commit, bigger grid (256):
![Capture du 2020-02-11 23-44-00_snap256](https://user-images.githubusercontent.com/47089717/74287194-a8d8cd80-4d29-11ea-9e2a-b5ea97dcac25.png)

Symplify:
![Capture du 2020-02-11 23-42-02_simplify4](https://user-images.githubusercontent.com/47089717/74287180-a37b8300-4d29-11ea-9de1-66db82f1dd46.png)



