### PR TITLE
Add line-cap round for cycleway/path to avoid empty spaces

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -1577,21 +1577,18 @@ come in as well.
   [type='primary'],
   [type='secondary'],
   [type='motorway'],
-  [type='trunk'] {
+  [type='trunk'],
+  [type='cycleway'],
+  [type='pedestrian'],
+  [type='bridleway'],
+  [type='footway'],
+  [type='path'] {
     line-cap: round;
     line-join: round;
   }
 
   [tunnel=1] {
     line-cap: butt;
-  }
-
-  [type='cycleway'],
-  [type='pedestrian'],
-  [type='bridleway'],
-  [type='footway'],
-  [type='path'] {
-    line-join: round;
   }
 
   /* -- widths -- */


### PR DESCRIPTION
Fix #224 

Before:
![Capture du 2020-03-15 18-00-24](https://user-images.githubusercontent.com/47089717/76706346-10968580-66e7-11ea-9603-b9648296a7cf.png)

After:
![Capture du 2020-03-15 18-00-34](https://user-images.githubusercontent.com/47089717/76706351-17bd9380-66e7-11ea-8ed7-082def291222.png)
