### PR TITLE
Improve density of city names in countryside at Z10/Z11. Fix #195.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix a bug with some protected areas labels not rendered. See #329.
 * Render `highway=bridleway` + `bicycle=designated` as a shared path. See #215.
 * Render indoor paths in faded color. See #334.
+* Improve density of city names in countryside at Z10/Z11. See #195.
 
 
 ## v0.3.4

--- a/placenames.mss
+++ b/placenames.mss
@@ -318,6 +318,8 @@
 
 #placenames-small::village {
   [place = 'village'] {
+    [zoom >= 10][population >= 1000][zoom < 11],
+    [zoom >= 11][population >= 500][zoom < 12],
     [zoom >= 12][zoom < 17] {
       text-name: "[name]";
       text-size: 10;

--- a/placenames.mss
+++ b/placenames.mss
@@ -318,8 +318,8 @@
 
 #placenames-small::village {
   [place = 'village'] {
-    [zoom >= 10][population >= 1000][zoom < 11],
-    [zoom >= 11][population >= 500][zoom < 12],
+    [zoom = 10][population >= 1000][row_number <= 10],
+    [zoom = 11][population >= 500][row_number <= 40],
     [zoom >= 12][zoom < 17] {
       text-name: "[name]";
       text-size: 10;

--- a/project.mml
+++ b/project.mml
@@ -1357,33 +1357,43 @@ Layer:
   Datasource:
     <<: *osm2pgsql
     table: |-
-      (SELECT
-          way,
-          place,
-          leisure,
-          name,
-          CASE
-            WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER ELSE 0
-          END as population
-        FROM planet_osm_point
-        WHERE place IN ('village', 'hamlet')
-           AND name IS NOT NULL
-           AND NOT (capital IS NOT NULL AND capital='yes')
-           OR (place IN ('suburb', 'quarter', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
-               OR (place IN ('square')
-                   AND (leisure is NULL OR NOT leisure IN ('park', 'common', 'recreation_ground', 'garden')))
-           ) AND name IS NOT NULL
-        ORDER BY CASE
-            WHEN place = 'suburb' THEN 3
-            WHEN place = 'village' THEN 4
-            WHEN place = 'hamlet' THEN 5
-            WHEN place = 'quarter' THEN 6
-            WHEN place = 'neighbourhood' THEN 7
-            WHEN place = 'locality' THEN 8
-            WHEN place = 'isolated_dwelling' THEN 9
-            WHEN place = 'farm' THEN 10
-            WHEN place = 'square' THEN 11
-          END ASC, length(name) DESC, name
+      (
+        SELECT *, ROW_NUMBER() OVER () AS row_number
+        FROM (
+          SELECT
+            way,
+            place,
+            leisure,
+            name,
+            CASE
+              WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER ELSE 0
+            END as population
+          FROM planet_osm_point
+          WHERE way && !bbox! AND (
+            place IN ('village', 'hamlet')
+            AND name IS NOT NULL
+            AND NOT (capital IS NOT NULL AND capital='yes')
+            OR (place IN ('suburb', 'quarter', 'neighbourhood', 'locality', 'isolated_dwelling', 'farm')
+                OR (place IN ('square')
+                    AND (leisure is NULL OR NOT leisure IN ('park', 'common', 'recreation_ground', 'garden')))
+            ) AND name IS NOT NULL
+          )
+          ORDER BY
+            population DESC,
+            CASE
+              WHEN place = 'suburb' THEN 3
+              WHEN place = 'village' THEN 4
+              WHEN place = 'hamlet' THEN 5
+              WHEN place = 'quarter' THEN 6
+              WHEN place = 'neighbourhood' THEN 7
+              WHEN place = 'locality' THEN 8
+              WHEN place = 'isolated_dwelling' THEN 9
+              WHEN place = 'farm' THEN 10
+              WHEN place = 'square' THEN 11
+            END ASC,
+            length(name) DESC,
+            name
+        ) AS data2
       ) AS data
   properties:
     cache-features: true

--- a/project.mml
+++ b/project.mml
@@ -1361,7 +1361,10 @@ Layer:
           way,
           place,
           leisure,
-          name
+          name,
+          CASE
+            WHEN (population ~ '^[0-9]{1,8}$') THEN population::INTEGER ELSE 0
+          END as population
         FROM planet_osm_point
         WHERE place IN ('village', 'hamlet')
            AND name IS NOT NULL
@@ -1384,7 +1387,7 @@ Layer:
       ) AS data
   properties:
     cache-features: true
-    minzoom: 12
+    minzoom: 10
 - id: area_label
   <<: *extents
   Datasource:


### PR DESCRIPTION
Here is an attempt at tackling #195. I find it not too bad in this area, but deserves more testing.

Village with population >= 1000 are shown at Z10 :

![2020-03-30-203854](https://user-images.githubusercontent.com/3856586/77949255-ecca6680-72c6-11ea-9c8d-31aa5c9a0b94.png)

Village with population >= 500 are shown at Z11 :

![2020-03-30-204017](https://user-images.githubusercontent.com/3856586/77949278-f784fb80-72c6-11ea-94d7-601299d6583c.png)
