### PR TITLE
Render mtb scales on path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix a bug with some protected areas labels not rendered. See #329.
 * Render `highway=bridleway` + `bicycle=designated` as a shared path. See #215.
 * Render indoor paths in faded color. See #334.
+* Render `mtb:scale` and `mtb:scale:imba`. See #336.
 
 
 ## v0.3.4

--- a/project.mml
+++ b/project.mml
@@ -708,7 +708,7 @@ Layer:
             ELSE NULL
           END AS surface_type,
           CASE
-            WHEN tags->'mtb:scale'~E'^\\d+$' THEN (tags->'mtb:scale')::integer
+            WHEN tags->'mtb:scale'~E'^\\d+[+-]?$' THEN REPLACE(REPLACE(tags->'mtb:scale', '+', ''), '-', '')::integer
             ELSE NULL
           END AS mtb_scale,
           CASE

--- a/project.mml
+++ b/project.mml
@@ -543,7 +543,6 @@ Layer:
             tags->'ramp:wheelchair',
             tags->'ramp:luggage'
           ) AS has_ramp,
-          surface, tracktype, tags->'smoothness' AS smoothness,
           CASE
             -- From best tag to less precise quality surface tag (smoothness > track > surface).
             WHEN tags->'smoothness' IN ('horrible', 'very_horrible', 'impassable')
@@ -692,7 +691,6 @@ Layer:
             tags->'ramp:wheelchair',
             tags->'ramp:luggage'
           ) AS has_ramp,
-          surface, tracktype, tags->'smoothness' AS smoothness,
           CASE
             -- From best tag to less precise quality surface tag (smoothness > track > surface).
             WHEN tags->'smoothness' IN ('horrible', 'very_horrible', 'impassable')
@@ -709,6 +707,7 @@ Layer:
               THEN 'cyclocross'
             ELSE NULL
           END AS surface_type,
+
           CASE
             WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+39 ELSE 39 END
             WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+38 ELSE 38 END
@@ -932,7 +931,6 @@ Layer:
             tags->'ramp:wheelchair',
             tags->'ramp:luggage'
           ) AS has_ramp,
-          surface, tracktype, tags->'smoothness' AS smoothness,
           CASE
             -- From best tag to less precise quality surface tag (smoothness > track > surface).
             WHEN tags->'smoothness' IN ('horrible', 'very_horrible', 'impassable')

--- a/project.mml
+++ b/project.mml
@@ -707,7 +707,14 @@ Layer:
               THEN 'cyclocross'
             ELSE NULL
           END AS surface_type,
-
+          CASE
+            WHEN tags->'mtb:scale'~E'^\\d+$' THEN (tags->'mtb:scale')::integer
+            ELSE NULL
+          END AS mtb_scale,
+          CASE
+            WHEN tags->'mtb:scale:imba'~E'^\\d+$' THEN (tags->'mtb:scale:imba')::integer
+            ELSE NULL
+          END AS mtb_scale_imba,
           CASE
             WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+39 ELSE 39 END
             WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+38 ELSE 38 END

--- a/roads.mss
+++ b/roads.mss
@@ -2201,8 +2201,8 @@ come in as well.
   }
 }
 
-#roads_high::mtbscale[mtb_scale>=0][zoom>=15],
-#roads_high::mtbscale[mtb_scale_imba>=0][zoom>=15]
+
+#roads_high::mtbscale[mtb_scale>=0][zoom>=15]
 {
   [type='service'],
   [type='track'],
@@ -2212,48 +2212,22 @@ come in as well.
   [type='cycleway']
   {
     line-color: #2076ff;
-    line-dasharray: 1,7;
+    line-dasharray: 1,8;
 
     [mtb_scale=1] {
-      line-dasharray: 1,1,1,7;
+      line-dasharray: 1,1,1,8;
     }
-
     [mtb_scale=2] {
       line-color: #FF0000;
     }
     [mtb_scale>=3] {
-      line-color: #000000;
+      line-color: #000000; //one dash |
     }
     [mtb_scale=4] {
-      line-dasharray: 1,1,1,7;
+      line-dasharray: 1,1,1,8;// 2 ||
     }
     [mtb_scale=5] {
-      line-dasharray: 1,1,1,1,1,7;
-    }
-
-    [mtb_scale=null]
-    {
-      [mtb_scale_imba>=0] {
-        line-color: #FFFFFF;
-        line-dasharray: 1,7;
-      }
-
-      [mtb_scale_imba>=1] {
-        line-color: #4e9b00;
-        line-dasharray: 1,7;
-      }
-      [mtb_scale_imba>=2] {
-        line-color: #2076ff;
-        line-dasharray: 1,7;
-      }
-      [mtb_scale_imba>=3] {
-        line-color: #000000;
-        line-dasharray: 1,7;
-      }
-      [mtb_scale_imba>=4] {
-        line-color: #000000;
-        line-dasharray: 1,1,1,7;
-      }
+      line-dasharray: 1,1,1,1,1,8;// 3 |||
     }
 
     [zoom>=15] {
@@ -2267,6 +2241,52 @@ come in as well.
     }
     [zoom>=18] {
       line-width: @rdz18_path*3;
+    }
+  }
+}
+//#roads_high::mtbscale[mtb_scale_imba>=0][zoom>=15]
+#roads_high::mtbscale[mtb_scale=null][mtb_scale_imba>=0][zoom>=15]
+{
+  [type='service'],
+  [type='track'],
+  [type='bridleway'],
+  [type='footway'],
+  [type='path'],
+  [type='cycleway']
+  {
+    line-cap: round;
+    line-color: #FFFFFF;
+    line-dasharray: 0.1,12;
+
+    [mtb_scale_imba>=1] {
+      line-color: #4e9b00;
+    }
+    [mtb_scale_imba>=2] {
+      line-color: #2076ff;
+    }
+    [mtb_scale_imba>=3] {
+      line-color: #000000;
+    }
+    [mtb_scale_imba>=4] {
+      line-color: #000000;
+      line-dasharray: 0.1,4,0.1,18;
+    }
+
+    [zoom>=15] {
+      line-width: @rdz15_path*3;
+    }
+    [zoom>=16] {
+      line-width: @rdz16_path*3;
+    }
+    [zoom>=17] {
+      line-width: @rdz17_path*2;
+      line-dasharray: 0.1,24;
+      [mtb_scale_imba>=4] {
+        line-dasharray: 0.1,4,0.1,36;
+      }
+    }
+    [zoom>=18] {
+      line-width: @rdz18_path*2;
     }
   }
 }

--- a/roads.mss
+++ b/roads.mss
@@ -2211,9 +2211,7 @@ come in as well.
   [type='path'],
   [type='cycleway']
   {
-    //test mtb_scale
     line-color: #0000FF;
-    //line-color: #000000;
     line-dasharray: 1,5;
 
     [mtb_scale>=2] {
@@ -2227,8 +2225,10 @@ come in as well.
 
     [mtb_scale=null]
     {
-      line-color: #FFFFFF;
-      line-dasharray: 1,7;
+      [mtb_scale_imba>=0] {
+        line-color: #FFFFFF;
+        line-dasharray: 1,7;
+      }
 
       [mtb_scale_imba>=1] {
         line-color: #4e9b00;

--- a/roads.mss
+++ b/roads.mss
@@ -2201,7 +2201,8 @@ come in as well.
   }
 }
 
-#roads_high::mtbscale[mtb_scale>=1][zoom>=15]
+#roads_high::mtbscale[mtb_scale>=1][zoom>=15],
+#roads_high::mtbscale[mtb_scale_imba>=0][zoom>=15]
 {
   [type='service'],
   [type='track'],
@@ -2210,6 +2211,7 @@ come in as well.
   [type='path'],
   [type='cycleway']
   {
+    //test mtb_scale
     line-color: #0000FF;
     //line-color: #000000;
     line-dasharray: 1,5;
@@ -2221,6 +2223,29 @@ come in as well.
     [mtb_scale>=3] {
       line-color: #000000;
       line-dasharray: 1,1,1,1,1,5;
+    }
+
+    [mtb_scale=null]
+    {
+      line-color: #FFFFFF;
+      line-dasharray: 1,7;
+
+      [mtb_scale_imba>=1] {
+        line-color: #4e9b00;
+        line-dasharray: 1,7;
+      }
+      [mtb_scale_imba>=2] {
+        line-color: #2076ff;
+        line-dasharray: 1,7;
+      }
+      [mtb_scale_imba>=3] {
+        line-color: #000000;
+        line-dasharray: 1,7;
+      }
+      [mtb_scale_imba>=4] {
+        line-color: #000000;
+        line-dasharray: 1,1,1,7;
+      }
     }
 
     [zoom>=15] {

--- a/roads.mss
+++ b/roads.mss
@@ -2201,6 +2201,43 @@ come in as well.
   }
 }
 
+#roads_high::mtbscale[mtb_scale>=1][zoom>=15]
+{
+  [type='service'],
+  [type='track'],
+  [type='bridleway'],
+  [type='footway'],
+  [type='path'],
+  [type='cycleway']
+  {
+    line-color: #0000FF;
+    //line-color: #000000;
+    line-dasharray: 1,5;
+
+    [mtb_scale>=2] {
+      line-color: #FF0000;
+      line-dasharray: 1,1,1,5;
+    }
+    [mtb_scale>=3] {
+      line-color: #000000;
+      line-dasharray: 1,1,1,1,1,5;
+    }
+
+    [zoom>=15] {
+      line-width: @rdz15_path*3;
+    }
+    [zoom>=16] {
+      line-width: @rdz16_path*3;
+    }
+    [zoom>=17] {
+      line-width: @rdz17_path*3;
+    }
+    [zoom>=18] {
+      line-width: @rdz18_path*3;
+    }
+  }
+}
+
 
 #roads_high::rail_line[zoom>=11],
 #bridge::rail_line[zoom>=11] {

--- a/roads.mss
+++ b/roads.mss
@@ -2201,7 +2201,7 @@ come in as well.
   }
 }
 
-#roads_high::mtbscale[mtb_scale>=1][zoom>=15],
+#roads_high::mtbscale[mtb_scale>=0][zoom>=15],
 #roads_high::mtbscale[mtb_scale_imba>=0][zoom>=15]
 {
   [type='service'],
@@ -2211,16 +2211,24 @@ come in as well.
   [type='path'],
   [type='cycleway']
   {
-    line-color: #0000FF;
-    line-dasharray: 1,5;
+    line-color: #2076ff;
+    line-dasharray: 1,7;
 
-    [mtb_scale>=2] {
+    [mtb_scale=1] {
+      line-dasharray: 1,1,1,7;
+    }
+
+    [mtb_scale=2] {
       line-color: #FF0000;
-      line-dasharray: 1,1,1,5;
     }
     [mtb_scale>=3] {
       line-color: #000000;
-      line-dasharray: 1,1,1,1,1,5;
+    }
+    [mtb_scale=4] {
+      line-dasharray: 1,1,1,7;
+    }
+    [mtb_scale=5] {
+      line-dasharray: 1,1,1,1,1,7;
     }
 
     [mtb_scale=null]


### PR DESCRIPTION
mtb:scale is rendered with dashes with STS colors (with simple, double or triple dashes).
mtb:scale:imba is rendered with dots with IMBA colors (double diamond is double dot).
If both is present mtb:scale is used.
Rendered on path (foot/bridle/cycle/path), track, service roads, from zoom 15.
fix #336 

STS :
![Screenshot_20200406_160059](https://user-images.githubusercontent.com/47089717/78568539-898a8800-7822-11ea-8e0e-b2b27503b6ab.png)
![Screenshot_20200406_160035](https://user-images.githubusercontent.com/47089717/78568542-8abbb500-7822-11ea-9806-2908cfd5f29a.png)

IMBA :
![Screenshot_20200406_155730](https://user-images.githubusercontent.com/47089717/78568476-75df2180-7822-11ea-9f5c-687a3cb62189.png)
![Screenshot_20200406_155600](https://user-images.githubusercontent.com/47089717/78568480-7677b800-7822-11ea-8ecc-79a1ab21b651.png)

both (rare case) :
![Screenshot_20200406_160653](https://user-images.githubusercontent.com/47089717/78568581-97400d80-7822-11ea-9e3d-1f8d76fd720d.png)