### PR TITLE
Smooth the transition between z11 and z13 on z12 for cycle path width.

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -170,7 +170,7 @@ come in as well.
 @rdz12_track: 0.5;
 @rdz12_pedestrian: 0.5;
 @rdz12_path: 0.5;
-@rdz12_cycle: 1;
+@rdz12_cycle: 0.8;
 @rdz12_railway: 0.5;
 /* Border width (one side of the road only) */
 @rdz12_motorway_trunk_outline: 1;


### PR DESCRIPTION
Problem on cities with many cycleways the cycleways take too much place/volume, see Amsterdam

![Screenshot_20200413_154251](https://user-images.githubusercontent.com/47089717/79124933-9a487a00-7d9d-11ea-8c7d-616632e44db6.png)

Example with fix :
![Screenshot_20200413_154031](https://user-images.githubusercontent.com/47089717/79124975-a92f2c80-7d9d-11ea-80df-85e629ff04be.png)
