### PR TITLE
Color balance

### DIFF
--- a/road-colors-generated.mss
+++ b/road-colors-generated.mss
@@ -31,9 +31,9 @@
 @secondary-case: #b1bb5d;
 @secondary-fill: #f6f8d2;
 @speed32-fill: #bbffff;
-@speed20-fill: #c1f0c1;
-@speedWalk-fill: #def0c4;
-@nomotor-fill: #8bff62;
+@speed20-fill: #bbffba;
+@speedWalk-fill: #ddffba;
+@nomotor-fill: #62ff96;
 @standard-case: #888;
 @standard-fill: #f6f6f6;
 @standard-nobicycle: #d4d4d4;

--- a/road-colors-generated.mss
+++ b/road-colors-generated.mss
@@ -4,25 +4,24 @@
 /*                                                                       */
 /*   ./scripts/generate_road_colors.py | tee road-colors-generated.mss   */
 /*                                                                       */
-@cycle-case: @land;
 @cycle-fill: #0000ce;
 @mixed-cycle-fill: #0060ff;
-@path-fill: #008662;
-@footway-fill: #b0a187;
-@bridleway-fill: #835d4b;
+@path-fill: #008670;
+@footway-fill: #9d866c;
+@bridleway-fill: #812e28;
 @icn-overlay: #ff00ff;
 @icn-shield-fill: #f6f6f6;
 @lcn-overlay: #0000ff;
 @lcn-shield-fill: #f6f6f6;
 @motorway-trunk-case: #f6f6f6;
 @motorway-trunk-cycle-fill: #f4c3c3;
-@motorway-trunk-fill: #c0ccc4;
+@motorway-trunk-fill: #d4d4d4;
 @motorway-trunk-line: #f6f6f6;
 @mtb-overlay: #d15000;
 @mtb-shield-fill: #f6f6f6;
 @ncn-overlay: #aa00ff;
 @ncn-shield-fill: #f6f6f6;
-@pedestrian-case: @land;
+@pedestrian-case: #bbb;
 @pedestrian-fill: @speedWalk-fill;
 @primary-case: #d8b267;
 @primary-fill: #f4dfc3;
@@ -31,16 +30,16 @@
 @rcn-shield-fill: #f6f6f6;
 @secondary-case: #b1bb5d;
 @secondary-fill: #f6f8d2;
-@speed32-fill: #b8efff;
-@speed20-fill: #b8ffce;
-@speedWalk-fill: #ddf0c4;
-@standard-case: #999;
+@speed32-fill: #bbffff;
+@speed20-fill: #c1f0c1;
+@speedWalk-fill: #def0c4;
+@nomotor-fill: #8bff62;
+@standard-case: #888;
 @standard-fill: #f6f6f6;
-@standard-nobicycle: #c0ccc4;
+@standard-nobicycle: #d4d4d4;
 @tertiary-case: #777;
 @tertiary-fill: #f6f6f6;
 @tertiary-line: #f6f6f6;
-@track-case: #cdae8c;
-@track-fill: #1e4374;
+@track-fill: #1b3b66;
 @track-light1: lighten(@track-fill, 30%);
 @track-light2: lighten(@track-fill, 50);

--- a/road-colors-generated.mss
+++ b/road-colors-generated.mss
@@ -8,7 +8,7 @@
 @cycle-fill: #0000ce;
 @mixed-cycle-fill: #0060ff;
 @path-fill: #008662;
-@footway-fill: #cab38a;
+@footway-fill: #b0a187;
 @bridleway-fill: #835d4b;
 @icn-overlay: #ff00ff;
 @icn-shield-fill: #f6f6f6;
@@ -23,7 +23,7 @@
 @ncn-overlay: #aa00ff;
 @ncn-shield-fill: #f6f6f6;
 @pedestrian-case: @land;
-@pedestrian-fill: #b0ffb0;
+@pedestrian-fill: @speedWalk-fill;
 @primary-case: #d8b267;
 @primary-fill: #f4dfc3;
 @rail-line: #888888;
@@ -31,9 +31,9 @@
 @rcn-shield-fill: #f6f6f6;
 @secondary-case: #b1bb5d;
 @secondary-fill: #f6f8d2;
-@speed32-fill: #8ce5ff;
-@speed20-fill: #66ffc7;
-@speedWalk-fill: #b0ffb0;
+@speed32-fill: #b8efff;
+@speed20-fill: #b8ffce;
+@speedWalk-fill: #ddf0c4;
 @standard-case: #999;
 @standard-fill: #f6f6f6;
 @standard-nobicycle: #c0ccc4;

--- a/road-colors-generated.mss
+++ b/road-colors-generated.mss
@@ -16,7 +16,6 @@
 @motorway-trunk-case: #f6f6f6;
 @motorway-trunk-cycle-fill: #f4c3c3;
 @motorway-trunk-fill: #d4d4d4;
-@motorway-trunk-line: #f6f6f6;
 @mtb-overlay: #d15000;
 @mtb-shield-fill: #f6f6f6;
 @ncn-overlay: #aa00ff;

--- a/road-colors-generated.mss
+++ b/road-colors-generated.mss
@@ -4,15 +4,16 @@
 /*                                                                       */
 /*   ./scripts/generate_road_colors.py | tee road-colors-generated.mss   */
 /*                                                                       */
-@bridleway-fill: #835d4b;
 @cycle-case: @land;
-@cycle-fill: #0000ff;
-@footway-fill: #4f874f;
+@cycle-fill: #0000ce;
+@mixed-cycle-fill: #0060ff;
+@path-fill: #008662;
+@footway-fill: #cab38a;
+@bridleway-fill: #835d4b;
 @icn-overlay: #ff00ff;
 @icn-shield-fill: #f6f6f6;
 @lcn-overlay: #0000ff;
 @lcn-shield-fill: #f6f6f6;
-@mixed-cycle-fill: #0050ff;
 @motorway-trunk-case: #f6f6f6;
 @motorway-trunk-cycle-fill: #f4c3c3;
 @motorway-trunk-fill: #c0ccc4;
@@ -21,9 +22,8 @@
 @mtb-shield-fill: #f6f6f6;
 @ncn-overlay: #aa00ff;
 @ncn-shield-fill: #f6f6f6;
-@path-fill: #00767c;
 @pedestrian-case: @land;
-@pedestrian-fill: #41ffa0;
+@pedestrian-fill: #b0ffb0;
 @primary-case: #d8b267;
 @primary-fill: #f4dfc3;
 @rail-line: #888888;
@@ -31,9 +31,9 @@
 @rcn-shield-fill: #f6f6f6;
 @secondary-case: #b1bb5d;
 @secondary-fill: #f6f8d2;
-@speed20-fill: #21ffcc;
-@speed32-fill: #bbffff;
-@speedWalk-fill: #41ffa0;
+@speed32-fill: #8ce5ff;
+@speed20-fill: #66ffc7;
+@speedWalk-fill: #b0ffb0;
 @standard-case: #999;
 @standard-fill: #f6f6f6;
 @standard-nobicycle: #c0ccc4;

--- a/roads.mss
+++ b/roads.mss
@@ -11,7 +11,7 @@ and trunks. */
   }
 
   [type='motorway'] {
-    line-color: @motorway-trunk-line;
+    line-color: @motorway-trunk-fill;
     [bicycle='yes'] {
       line-color: @motorway-trunk-cycle-fill;
     }
@@ -19,7 +19,7 @@ and trunks. */
   [type='trunk'] {
     line-color: @motorway-trunk-cycle-fill;
     [bicycle='no'] {
-      line-color: @motorway-trunk-line;
+      line-color: @motorway-trunk-fill;
     }
   }
 
@@ -1521,7 +1521,7 @@ come in as well.
         line-color: lighten(@speedWalk-fill, 10%);
       }
     }
-    [motor_vehicle='no'][can_bicycle!='no'] {
+    [motor_vehicle='no'][can_bicycle!='no'][type!='pedestrian'] {
         line-color: @nomotor-fill;
         [tunnel=1] {
           line-color: lighten(@nomotor-fill, 10%);

--- a/roads.mss
+++ b/roads.mss
@@ -1471,7 +1471,7 @@ come in as well.
   [type='steps'] {
     line-color: @footway-fill;
     [tunnel=1] {
-      line-color: lighten(@footway-fill, 30%);
+      line-color: lighten(@footway-fill, 20%);
     }
   }
   [type='path'] {

--- a/roads.mss
+++ b/roads.mss
@@ -374,7 +374,7 @@ come in as well.
 @rdz17_service: 6;
 @rdz17_track: 4;
 @rdz17_pedestrian: 3;
-@rdz17_bridleway: 1;
+@rdz17_bridleway: 1.5;
 @rdz17_path: 2;
 @rdz17_footway: 1.5;
 @rdz17_steps: 3;
@@ -417,7 +417,7 @@ come in as well.
 @rdz18_service: 10;
 @rdz18_track: 7;
 @rdz18_pedestrian: 4;
-@rdz18_bridleway: 1.5;
+@rdz18_bridleway: 2;
 @rdz18_path: 2.5;
 @rdz18_footway: 2;
 @rdz18_steps: 3.5;
@@ -451,10 +451,9 @@ come in as well.
 #tunnel::outline[zoom>=11],
 #bridge::outline[zoom>=11] {
   line-cap: round;
-
   line-join: round;
-
   line-color: @standard-case;
+
   [type='motorway'],
   [type='motorway_link'],
   [type='trunk'],
@@ -473,6 +472,10 @@ come in as well.
   [type='tertiary_link'],
   [type='unclassified'] {
     line-color: @tertiary-case;
+  }
+  [type='pedestrian'],
+  [type='living_street'] {
+    line-color: @pedestrian-case;
   }
 
   /* -- widths -- */
@@ -1496,27 +1499,34 @@ come in as well.
   }
 
   /* Maxspeed bike friendliness only applies to a limited set of highways */
-  [type != 'trunk_link'][type != 'motorway_link'][type != 'motorway'][type != 'trunk'][type != 'path'][type != 'cycleway'][type != 'track'][type != 'railway'][cyclestreet != 'yes'] {
-      /* low maxspeed roads are bike friendly */
-      [maxspeed_kmh < 33] {
-          line-color: @speed32-fill;
-          [tunnel=1] {
-            line-color: lighten(@speed32-fill, 10%);
-          }
+  [type != 'trunk_link'][type != 'motorway_link'][type != 'motorway'][type != 'trunk']
+  [type != 'path'][type != 'cycleway'][type != 'footway'][type != 'bridleway']
+  [type != 'track'][type != 'railway'][cyclestreet != 'yes'] {
+    /* low maxspeed roads are bike friendly */
+    [maxspeed_kmh < 33] {
+        line-color: @speed32-fill;
+        [tunnel=1] {
+          line-color: lighten(@speed32-fill, 10%);
+        }
+    }
+    [maxspeed_kmh < 21] {
+        line-color: @speed20-fill;
+        [tunnel=1] {
+          line-color: lighten(@speed20-fill, 10%);
+        }
+    }
+    [maxspeed_kmh < 10] {
+      line-color: @speedWalk-fill;
+      [tunnel=1] {
+        line-color: lighten(@speedWalk-fill, 10%);
       }
-      [maxspeed_kmh < 21] {
-          line-color: @speed20-fill;
-          [tunnel=1] {
-            line-color: lighten(@speed20-fill, 10%);
-          }
-      }
-      [maxspeed_kmh < 10],
-      [motor_vehicle='no'][can_bicycle!='no'] {
-          line-color: @speedWalk-fill;
-          [tunnel=1] {
-            line-color: lighten(@speedWalk-fill, 10%);
-          }
-      }
+    }
+    [motor_vehicle='no'][can_bicycle!='no'] {
+        line-color: @nomotor-fill;
+        [tunnel=1] {
+          line-color: lighten(@nomotor-fill, 10%);
+        }
+    }
     [can_bicycle='no'],
     [can_bicycle='private'] {
       line-color: @standard-nobicycle;


### PR DESCRIPTION
This move the "foot color" from green to brown in order to have wider range of colors fixing #324 
- footway : light brown
- cycleway : darker blue
- shared designated path : a little lighter blue
- path : little greener
- speed colors : wider shading to green/yellow
- lighten casing for pedestrian and living streets
- redder bigger (as footway) for bridleways
- grey nobicycle roads
- fix maxspeed/no_motor color on footway-bridleway
- add no_motor color since pedestrian color is not hard enough
- darken a little track color
- remove not used colors
- Draw motorway in grey instead of white in low zooms.
- Pedestrian with nomotor use pedestrian color instead of nomotor color, because (many) pedestrian is more important information than no vehicles at all for a cyclist.
- darker road casing, for better contrast

I didn't change the color in the file road-colors.yml and didn't used the script because it's very boring, and useless ? Should be cleaned.

before/after examples :
![Screenshot_20200418_120107](https://user-images.githubusercontent.com/47089717/79635744-08f94f00-8173-11ea-83a7-ee01f2cc6fa8.png)
![Screenshot_20200418_120004](https://user-images.githubusercontent.com/47089717/79635745-0a2a7c00-8173-11ea-95f6-964ae5a80f70.png)
![Screenshot_20200418_114347](https://user-images.githubusercontent.com/47089717/79635748-0ac31280-8173-11ea-9a03-394a9864f888.png)
![Screenshot_20200418_114220](https://user-images.githubusercontent.com/47089717/79635752-0b5ba900-8173-11ea-8dac-9944c60776e3.png)
![Screenshot_20200418_113828](https://user-images.githubusercontent.com/47089717/79635753-0bf43f80-8173-11ea-8f2f-fcdb0476da29.png)
![Screenshot_20200418_113744](https://user-images.githubusercontent.com/47089717/79635756-0c8cd600-8173-11ea-9014-3ce79d680dd2.png)
![Screenshot_20200418_113703](https://user-images.githubusercontent.com/47089717/79635757-0d256c80-8173-11ea-8e57-d38c8e18b0da.png)

