### PR TITLE
Add blue arrows on designated roads.

### DIFF
--- a/labels.mss
+++ b/labels.mss
@@ -492,6 +492,35 @@
      }
   }
 }
+/* Render designated roads */
+#roads-text-name[highway != 'construction'][zoom>=15] {
+  [bicycle='designated'][oneway = 'yes'][oneway_bicycle != 'no'],
+  [bicycle='designated'][oneway = '-1'][oneway_bicycle != 'no'] {
+     designated/marker-placement: line;
+     designated/marker-max-error: 0.5;
+     designated/marker-spacing: 50;
+     designated/marker-fill: @cycle-fill;
+     designated/marker-file: url(symbols/oneway.svg);
+     [oneway='-1'] { bike/marker-file: url(symbols/oneway-reverse.svg); }
+     [zoom=15] {
+        bike/marker-transform: "scale(0.75)";
+        bike/marker-spacing: 40;
+     }
+  }
+  [bicycle='designated'][oneway = 'yes'][oneway_bicycle = 'no'],
+  [bicycle='designated'][oneway = '-1'][oneway_bicycle = 'no'],
+  [bicycle='designated'][oneway != 'yes'][oneway != '-1'][oneway_bicycle != 'yes'][oneway_bicycle != '-1'] {
+     designated/marker-placement: line;
+     designated/marker-max-error: 0.5;
+     designated/marker-spacing: 50;
+     designated/marker-fill: @cycle-fill;
+     designated/marker-file: url(symbols/oneway-cycle.svg);
+     [zoom=15] {
+        bike/marker-transform: "scale(0.75)";
+        bike/marker-spacing: 40;
+     }
+  }
+}
 
 
 /* ================================================================== */


### PR DESCRIPTION
Fix #304 
I didn't choose to draw a border dash line like shared busways or shared lanes because here it's the full road which is designate and bicycle=designated is not an infrastructure tag but an access (legal) tag.

![Screenshot_20200418_184028](https://user-images.githubusercontent.com/47089717/79644180-7de67c00-81a7-11ea-9b4a-e619719e0274.png)
![Screenshot_20200418_182506](https://user-images.githubusercontent.com/47089717/79644181-7e7f1280-81a7-11ea-905e-80bb32bfebb6.png)
![Screenshot_20200418_181933](https://user-images.githubusercontent.com/47089717/79644182-7f17a900-81a7-11ea-9fa5-df5796d4462d.png)
