### PR TITLE
Add support for running the style with Docker(-compose)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ dem/
 scripts/test/*.png
 scripts/test/*.txt
 tmp/
+.kosmtik-config.yml
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:bionic
+
+# Style dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    ca-certificates curl gnupg postgresql-client python fonts-hanazono \
+    fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted mapnik-utils \
+    nodejs npm ttf-unifont unzip && rm -rf /var/lib/apt/lists/*
+
+# Kosmtik with plugins, forcing prefix to /usr because bionic sets
+# npm prefix to /usr/local, which breaks the install
+RUN npm set prefix /usr && npm install -g kosmtik
+
+WORKDIR /usr/lib/node_modules/kosmtik/
+RUN kosmtik plugins --install kosmtik-overpass-layer \
+                    --install kosmtik-fetch-remote \
+                    --install kosmtik-overlay \
+                    --install kosmtik-open-in-josm \
+                    --install kosmtik-map-compare \
+                    --install kosmtik-osm-data-overlay \
+                    --install kosmtik-mapnik-reference \
+                    --install kosmtik-geojson-overlay \
+    && cp /root/.config/kosmtik.yml /tmp/.kosmtik-config.yml
+
+# Closing section
+RUN mkdir -p /cyclosm
+WORKDIR /cyclosm
+
+USER 1000
+CMD sh scripts/docker-startup.sh kosmtik

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,0 +1,3 @@
+FROM mdillon/postgis:10
+
+ADD ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,3 +1,3 @@
-FROM mdillon/postgis:10
+FROM mdillon/postgis
 
 ADD ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d

--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -1,0 +1,19 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    ca-certificates curl gnupg && rm -rf /var/lib/apt/lists/*
+
+RUN echo 'deb http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main\n\
+deb-src http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main' > \
+    /etc/apt/sources.list.d/osmadmins-ppa.list
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
+    --recv A438A16C88C6BE41CB1616B8D57F48750AC4F2CB
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    osm2pgsql postgresql-client && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /cyclosm
+WORKDIR /cyclosm
+
+CMD sh scripts/docker-startup.sh import

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '2'
+services:
+  kosmtik:
+    image: kosmtik:v1
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/openstreetmap-carto
+    depends_on:
+      - db
+    ports:
+      - "127.0.0.1:6789:6789"
+    environment:
+      - PGHOST=db
+      - PGUSER=postgres
+  db:
+    image: db:v1
+    build:
+      context: .
+      dockerfile: Dockerfile.db
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      - PG_WORK_MEM
+      - PG_MAINTENANCE_WORK_MEM
+  import:
+    image: import:v1
+    build:
+      context: .
+      dockerfile: Dockerfile.import
+    volumes:
+      - .:/openstreetmap-carto
+    depends_on:
+      - db
+    environment:
+      - PGHOST=db
+      - PGUSER=postgres
+      - PG_WORK_MEM
+      - PG_MAINTENANCE_WORK_MEM
+      - OSM2PGSQL_CACHE
+      - OSM2PGSQL_NUMPROC
+      - OSM2PGSQL_DATAFILE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - .:/openstreetmap-carto
+      - .:/cyclosm
     depends_on:
       - db
     ports:
@@ -30,7 +30,7 @@ services:
       context: .
       dockerfile: Dockerfile.import
     volumes:
-      - .:/openstreetmap-carto
+      - .:/cyclosm
     depends_on:
       - db
     environment:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,79 @@
+# Running OpenStreetMap Carto with Docker
+
+[Docker](https://docker.com) is a virtualized environment running a [_Docker demon_](https://docs.docker.com/engine/docker-overview), in which you can run software without altering your host system permanently. The software components run in _containers_ that are easy to setup and tear down individually. The Docker demon can use operating-system-level virtualization (Linux, Windows) or a virtual machine (macOS, Windows).
+
+This allows to set up a development environment for OpenStreetMap Carto easily. Specifically, this environment consists of a
+PostgreSQL database to store the OpenStreetMap data and [Kosmtik](https://github.com/kosmtik/kosmtik) for previewing the style.
+
+## Prerequisites
+
+Docker is available for Linux, macOS and Windows. [Install](https://www.docker.com/get-docker) the software packaged for your host system in order
+to be able to run Docker containers. You also need Docker Compose, which should be available once you installed
+Docker itself. Otherwise you need to [install Docker Compose manually](https://docs.docker.com/compose/install/).
+
+You need sufficient disk space of _several Gigabytes_. Docker creates a disk image for its virtual machine that holds the virtualised operating system and the containers. The format (Docker.raw, Docker.qcow2, \*.vhdx, etc.) depends on the host system. It can be a sparse file allocating large amounts of disk space, but still the physical size starts with 2-3 GB for the virtual OS and grows to 6-7 GB when filled with the containers needed for the database, Kosmtik, and a small OSM region. Further 1-2 GB are needed for shape files in the openstreetmap-carto/data repository.
+
+## Quick start
+
+If you are eager to get started here is an overview over the necessary steps.
+Read on below to get the details.
+
+* `git clone https://github.com/gravitystorm/openstreetmap-carto.git` to clone openstreetmap-carto repository into a directory on your host system
+* download OpenStreetMap data in osm.pbf format to a file `data.osm.pbf` and place it within the openstreetmap-carto directory (for example some small area from [Geofabrik](https://download.geofabrik.de/))
+* If necessary, `sudo service postgresql stop` to make sure you don't have currently running a native PostgreSQL server which would conflict with Docker's PostgreSQL server.
+* `docker-compose up import` to import the data (only necessary the first time or when you change the data file)
+* `docker-compose up kosmtik` to run the style preview application
+* browse to [http://localhost:6789](http://localhost:6789) to view the output of Kosmtik
+* Ctrl+C to stop the style preview application
+* `docker-compose stop db` to stop the database container
+
+## Repositories
+
+Instructions above will clone main OpenStreetMap Carto repository. To test your own changes you should [fork](https://help.github.com/articles/fork-a-repo/) gravitystorm/openstreetmap-carto repository and [clone your fork](https://help.github.com/articles/cloning-a-repository/).
+
+This OpenStreetMap Carto repository needs to be a directory that is shared between your host system and the Docker virtual machine. Home directories are shared by default; if your repository is in another place you need to add this to the Docker sharing list (e.g. macOS: Docker Preferences > File Sharing; Windows: Docker Settings > Shared Drives).
+
+## Importing data
+
+OpenStreetMap Carto needs a database populated with rendering data to work. You first need a data file to import.
+It's probably easiest to grab an PBF of OSM data from [Geofabrik](https://download.geofabrik.de/).
+Once you have that file put it into the openstreetmap-carto directory and run `docker-compose up import` in the openstreetmap-carto directory.
+This starts the PostgreSQL container (downloads it if it not exists) and starts a container that runs [osm2pgsql](https://github.com/openstreetmap/osm2pgsql) to import the data. The container is built the first time you run that command if it not exists.
+At startup of the container the script `scripts/docker-startup.sh` is invoked which prepares the database and itself starts osm2pgsql for importing the data.
+
+osm2pgsql has a few [command line options](https://manpages.debian.org/testing/osm2pgsql/osm2pgsql.1.en.html) and the import by default uses a RAM cache of 512 MB, 1 worker and expects the import file to be named `data.osm.pbf`. If you want to customize any of these parameters you have to set the environment variables `OSM2PGSQL_CACHE` (e.g. `export OSM2PGSQL_CACHE=1024` on Linux to set the cache to 1 GB) for the RAM cache (the value depends on the amount of RAM you have available, the more you can use here the faster the import may be), `OSM2PGSQL_NUMPROC` for the number of workers (this depends on the number of processors you have and whether your harddisk is fast enough e.g. is a SSD), or `OSM2PGSQL_DATAFILE` if your file has a different name.
+
+You can also [tune the PostgreSQL](https://wiki.postgresql.org/wiki/Tuning_Your_PostgreSQL_Server) during the import phases, with `PG_WORK_MEM` (default to 16MB) and `PG_MAINTENANCE_WORK_MEM` (default to 256MB), which will eventually write `work_mem` and `maintenance_work_mem` to the `postgresql.auto.conf` once, making them applied each time the database started. Note that unlike osm2pgsql variables, once thay are set, you can only change them by running `ALTER SYSTEM` on your own, changing `postgresql.auto.conf` or remove the database volume by `docker-compose down -v && docker-compose rm -v` and import again.
+
+If you want to customize and remember the values, supply it during your first import:
+
+```
+PG_WORK_MEM=128MB PG_MAINTENANCE_WORK_MEM=2GB \
+OSM2PGSQL_CACHE=2048 OSM2PGSQL_NUMPROC=4 \
+OSM2PGSQL_DATAFILE=taiwan.osm.pbf \
+docker-compose up import
+```
+
+Variables will be remembered in `.env` if you don't have that file, and values in the file will be applied unless you manually assign them.
+
+Depending on your machine and the size of the extract the import can take a while. When it is finished you should have the data necessary to render it with OpenStreetMap Carto.
+
+## Test rendering
+
+After you have the necessary data available you can start Kosmtik to produce a test rendering. For that you run `docker-compose up kosmtik` in the openstreetmap-carto directory. This starts a container with Kosmtik and also starts the PostgreSQL database container if it is not already running. The Kosmtik container is built the first time you run that command if it not exists.
+At startup of the container the script `scripts/docker-startup.sh` is invoked which downloads necessary shapefiles with `scripts/get-shapefiles.py` (if they are not already present) and indexes them. It afterwards runs Kosmtik. If you have to customize anything, you can do so in the script. The Kosmtik config file can be found in `.kosmtik-config.yml`.
+If you want to have a [local configuration](https://github.com/kosmtik/kosmtik#local-config) for our `project.mml` you can place a `localconfig.js` or `localconfig.json` file into the openstreetmap-carto directory.
+
+The shapefile data that is downloaded is owned by the user with UID 1000. If you have another default user id on your system, consider changing the line `USER 1000` in the file `Dockerfile`.
+
+After startup is complete you can browse to [http://localhost:6789](http://localhost:6789) to view the output of Kosmtik. By pressing Ctrl+C on the command line you can stop the container. The PostgreSQL database container is still running then (you can check with `docker ps`). If you want to stop the database container as well you can do so by running `docker-compose stop db` in the openstreetmap-carto directory.
+
+## Troubleshooting
+
+Importing the data needs a substantial amount of RAM in the virtual machine. If you find the import process (Reading in file: data.osm.pbf, Processing) being _killed_ by the Docker demon, exiting with error code 137, increase the Memory assigned to Docker (e.g. macOS: Docker Preferences / Windows: Docker Settings > Advanced > Adjust the computing resources).
+
+Docker copies log files from the virtual machine into the host system, their [location depends on the host OS](https://stackoverflow.com/questions/30969435/where-is-the-docker-daemon-log). E.g. the 'console-ring' appears to be a ringbuffer of the console log, which can help to find reasons for killings.
+
+While installing software in the containers and populating the database, the disk image of the virtual machine grows in size, by Docker allocating more clusters. When the disk on the host system is full (only a few MB remaining), Docker can appear stuck. Watch the system log files of your host system for failed allocations.
+
+Docker stores its disk image by default in the home directories of the user. If you don't have enough space here, you can move it elsewhere. (E.g. macOS: Docker > Preferences > Disk).

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -61,10 +61,8 @@ Depending on your machine and the size of the extract the import can take a whil
 ## Test rendering
 
 After you have the necessary data available you can start Kosmtik to produce a test rendering. For that you run `docker-compose up kosmtik` in the CyclOSM directory. This starts a container with Kosmtik and also starts the PostgreSQL database container if it is not already running. The Kosmtik container is built the first time you run that command if it not exists.
-At startup of the container the script `scripts/docker-startup.sh` is invoked which downloads necessary shapefiles with `scripts/get-shapefiles.py` (if they are not already present) and indexes them. It afterwards runs Kosmtik. If you have to customize anything, you can do so in the script. The Kosmtik config file can be found in `.kosmtik-config.yml`.
+At startup of the container the script `scripts/docker-startup.sh` is invoked and runs Kosmtik. If you have to customize anything, you can do so in the script. The Kosmtik config file can be found in `.kosmtik-config.yml`.
 If you want to have a [local configuration](https://github.com/kosmtik/kosmtik#local-config) for our `project.mml` you can place a `localconfig.js` or `localconfig.json` file into the CyclOSM directory.
-
-The shapefile data that is downloaded is owned by the user with UID 1000. If you have another default user id on your system, consider changing the line `USER 1000` in the file `Dockerfile`.
 
 After startup is complete you can browse to [http://localhost:6789](http://localhost:6789) to view the output of Kosmtik. By pressing Ctrl+C on the command line you can stop the container. The PostgreSQL database container is still running then (you can check with `docker ps`). If you want to stop the database container as well you can do so by running `docker-compose stop db` in the CyclOSM directory.
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -18,7 +18,7 @@ You need sufficient disk space of _several Gigabytes_. Docker creates a disk ima
 If you are eager to get started here is an overview over the necessary steps.
 Read on below to get the details.
 
-* `git clone https://github.com/gravitystorm/openstreetmap-carto.git` to clone openstreetmap-carto repository into a directory on your host system
+* `git clone https://github.com/cyclosm/cyclosm-cartocss-style.git` to clone openstreetmap-carto repository into a directory on your host system
 * download OpenStreetMap data in osm.pbf format to a file `data.osm.pbf` and place it within the openstreetmap-carto directory (for example some small area from [Geofabrik](https://download.geofabrik.de/))
 * If necessary, `sudo service postgresql stop` to make sure you don't have currently running a native PostgreSQL server which would conflict with Docker's PostgreSQL server.
 * `docker-compose up import` to import the data (only necessary the first time or when you change the data file)
@@ -77,3 +77,9 @@ Docker copies log files from the virtual machine into the host system, their [lo
 While installing software in the containers and populating the database, the disk image of the virtual machine grows in size, by Docker allocating more clusters. When the disk on the host system is full (only a few MB remaining), Docker can appear stuck. Watch the system log files of your host system for failed allocations.
 
 Docker stores its disk image by default in the home directories of the user. If you don't have enough space here, you can move it elsewhere. (E.g. macOS: Docker > Preferences > Disk).
+
+## Notes
+
+This guide is based on the
+[`openstreetmap-carto`](https://github.com/gravitystorm/openstreetmap-carto/blob/master/DOCKER.md)
+Docker guide.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,8 +1,8 @@
-# Running OpenStreetMap Carto with Docker
+# Running CyclOSM with Docker
 
 [Docker](https://docker.com) is a virtualized environment running a [_Docker demon_](https://docs.docker.com/engine/docker-overview), in which you can run software without altering your host system permanently. The software components run in _containers_ that are easy to setup and tear down individually. The Docker demon can use operating-system-level virtualization (Linux, Windows) or a virtual machine (macOS, Windows).
 
-This allows to set up a development environment for OpenStreetMap Carto easily. Specifically, this environment consists of a
+This allows to set up a development environment for CyclOSM easily. Specifically, this environment consists of a
 PostgreSQL database to store the OpenStreetMap data and [Kosmtik](https://github.com/kosmtik/kosmtik) for previewing the style.
 
 ## Prerequisites
@@ -11,15 +11,15 @@ Docker is available for Linux, macOS and Windows. [Install](https://www.docker.c
 to be able to run Docker containers. You also need Docker Compose, which should be available once you installed
 Docker itself. Otherwise you need to [install Docker Compose manually](https://docs.docker.com/compose/install/).
 
-You need sufficient disk space of _several Gigabytes_. Docker creates a disk image for its virtual machine that holds the virtualised operating system and the containers. The format (Docker.raw, Docker.qcow2, \*.vhdx, etc.) depends on the host system. It can be a sparse file allocating large amounts of disk space, but still the physical size starts with 2-3 GB for the virtual OS and grows to 6-7 GB when filled with the containers needed for the database, Kosmtik, and a small OSM region. Further 1-2 GB are needed for shape files in the openstreetmap-carto/data repository.
+You need sufficient disk space of _several Gigabytes_. Docker creates a disk image for its virtual machine that holds the virtualised operating system and the containers. The format (Docker.raw, Docker.qcow2, \*.vhdx, etc.) depends on the host system. It can be a sparse file allocating large amounts of disk space, but still the physical size starts with 2-3 GB for the virtual OS and grows to 6-7 GB when filled with the containers needed for the database, Kosmtik, and a small OSM region. Further 1-2 GB are needed for shape files in the cyclosm/data repository.
 
 ## Quick start
 
 If you are eager to get started here is an overview over the necessary steps.
 Read on below to get the details.
 
-* `git clone https://github.com/cyclosm/cyclosm-cartocss-style.git` to clone openstreetmap-carto repository into a directory on your host system
-* download OpenStreetMap data in osm.pbf format to a file `data.osm.pbf` and place it within the openstreetmap-carto directory (for example some small area from [Geofabrik](https://download.geofabrik.de/))
+* `git clone https://github.com/cyclosm/cyclosm-cartocss-style.git` to clone CyclOSM repository into a directory on your host system
+* download OpenStreetMap data in osm.pbf format to a file `data.osm.pbf` and place it within the CyclOSM directory (for example some small area from [Geofabrik](https://download.geofabrik.de/))
 * If necessary, `sudo service postgresql stop` to make sure you don't have currently running a native PostgreSQL server which would conflict with Docker's PostgreSQL server.
 * `docker-compose up import` to import the data (only necessary the first time or when you change the data file)
 * `docker-compose up kosmtik` to run the style preview application
@@ -29,15 +29,15 @@ Read on below to get the details.
 
 ## Repositories
 
-Instructions above will clone main OpenStreetMap Carto repository. To test your own changes you should [fork](https://help.github.com/articles/fork-a-repo/) gravitystorm/openstreetmap-carto repository and [clone your fork](https://help.github.com/articles/cloning-a-repository/).
+Instructions above will clone main CyclOSM repository. To test your own changes you should [fork](https://help.github.com/articles/fork-a-repo/) cyclosm/cyclosm-cartocss-style repository and [clone your fork](https://help.github.com/articles/cloning-a-repository/).
 
-This OpenStreetMap Carto repository needs to be a directory that is shared between your host system and the Docker virtual machine. Home directories are shared by default; if your repository is in another place you need to add this to the Docker sharing list (e.g. macOS: Docker Preferences > File Sharing; Windows: Docker Settings > Shared Drives).
+This CyclOSM repository needs to be a directory that is shared between your host system and the Docker virtual machine. Home directories are shared by default; if your repository is in another place you need to add this to the Docker sharing list (e.g. macOS: Docker Preferences > File Sharing; Windows: Docker Settings > Shared Drives).
 
 ## Importing data
 
-OpenStreetMap Carto needs a database populated with rendering data to work. You first need a data file to import.
+CyclOSM needs a database populated with rendering data to work. You first need a data file to import.
 It's probably easiest to grab an PBF of OSM data from [Geofabrik](https://download.geofabrik.de/).
-Once you have that file put it into the openstreetmap-carto directory and run `docker-compose up import` in the openstreetmap-carto directory.
+Once you have that file put it into the CyclOSM directory and run `docker-compose up import` in the CyclOSM directory.
 This starts the PostgreSQL container (downloads it if it not exists) and starts a container that runs [osm2pgsql](https://github.com/openstreetmap/osm2pgsql) to import the data. The container is built the first time you run that command if it not exists.
 At startup of the container the script `scripts/docker-startup.sh` is invoked which prepares the database and itself starts osm2pgsql for importing the data.
 
@@ -56,17 +56,17 @@ docker-compose up import
 
 Variables will be remembered in `.env` if you don't have that file, and values in the file will be applied unless you manually assign them.
 
-Depending on your machine and the size of the extract the import can take a while. When it is finished you should have the data necessary to render it with OpenStreetMap Carto.
+Depending on your machine and the size of the extract the import can take a while. When it is finished you should have the data necessary to render it with CyclOSM.
 
 ## Test rendering
 
-After you have the necessary data available you can start Kosmtik to produce a test rendering. For that you run `docker-compose up kosmtik` in the openstreetmap-carto directory. This starts a container with Kosmtik and also starts the PostgreSQL database container if it is not already running. The Kosmtik container is built the first time you run that command if it not exists.
+After you have the necessary data available you can start Kosmtik to produce a test rendering. For that you run `docker-compose up kosmtik` in the CyclOSM directory. This starts a container with Kosmtik and also starts the PostgreSQL database container if it is not already running. The Kosmtik container is built the first time you run that command if it not exists.
 At startup of the container the script `scripts/docker-startup.sh` is invoked which downloads necessary shapefiles with `scripts/get-shapefiles.py` (if they are not already present) and indexes them. It afterwards runs Kosmtik. If you have to customize anything, you can do so in the script. The Kosmtik config file can be found in `.kosmtik-config.yml`.
-If you want to have a [local configuration](https://github.com/kosmtik/kosmtik#local-config) for our `project.mml` you can place a `localconfig.js` or `localconfig.json` file into the openstreetmap-carto directory.
+If you want to have a [local configuration](https://github.com/kosmtik/kosmtik#local-config) for our `project.mml` you can place a `localconfig.js` or `localconfig.json` file into the CyclOSM directory.
 
 The shapefile data that is downloaded is owned by the user with UID 1000. If you have another default user id on your system, consider changing the line `USER 1000` in the file `Dockerfile`.
 
-After startup is complete you can browse to [http://localhost:6789](http://localhost:6789) to view the output of Kosmtik. By pressing Ctrl+C on the command line you can stop the container. The PostgreSQL database container is still running then (you can check with `docker ps`). If you want to stop the database container as well you can do so by running `docker-compose stop db` in the openstreetmap-carto directory.
+After startup is complete you can browse to [http://localhost:6789](http://localhost:6789) to view the output of Kosmtik. By pressing Ctrl+C on the command line you can stop the container. The PostgreSQL database container is still running then (you can check with `docker ps`). If you want to stop the database container as well you can do so by running `docker-compose stop db` in the CyclOSM directory.
 
 ## Troubleshooting
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,7 +1,9 @@
 Getting started
 ===============
 
-This document describes how to manually configure your system for running CyclOSM. If you prefer quick, platform independent setup for a development environment, without the need to install and configure tools by hand, follow a Docker installation guide in [DOCKER.md](https://github.com/cyclosm/cyclosm-cartocss-style/blob/master/docs/DOCKER.md).
+This document describes how to manually configure your system for running CyclOSM. This guide is the recommended approach to run and develop CyclOSM.
+
+> There is also a quick, platform independent setup for a development environment, without the need to install and configure tools by hand, follow a Docker installation guide in [DOCKER.md](https://github.com/cyclosm/cyclosm-cartocss-style/blob/master/docs/DOCKER.md).
 
 ## Requirements
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,8 +1,7 @@
 Getting started
 ===============
 
-This document describes how to manually configure your system for running
-CyclOSM.
+This document describes how to manually configure your system for running CyclOSM. If you prefer quick, platform independent setup for a development environment, without the need to install and configure tools by hand, follow a Docker installation guide in [DOCKER.md](https://github.com/cyclosm/cyclosm-cartocss-style/blob/master/docs/DOCKER.md).
 
 ## Requirements
 

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+# This script is used to start the import of kosmtik containers for the Docker development environment.
+# You can read details about that in DOCKER.md
+
+# Testing if database is ready
+i=1
+MAXCOUNT=60
+echo "Waiting for PostgreSQL to be running"
+while [ $i -le $MAXCOUNT ]
+do
+  pg_isready -q && echo "PostgreSQL running" && break
+  sleep 2
+  i=$((i+1))
+done
+test $i -gt $MAXCOUNT && echo "Timeout while waiting for PostgreSQL to be running"
+
+case "$1" in
+import)
+  # Creating default database
+  psql -c "SELECT 1 FROM pg_database WHERE datname = 'gis';" | grep -q 1 || createdb gis && \
+  psql -d gis -c 'CREATE EXTENSION IF NOT EXISTS postgis;' && \
+  psql -d gis -c 'CREATE EXTENSION IF NOT EXISTS hstore;' && \
+
+  # Creating default import settings file editable by user and passing values for osm2pgsql
+  if [ ! -e ".env" ]; then
+    cat > .env <<EOF
+# Environment settings for importing to a Docker container database
+PG_WORK_MEM=${PG_WORK_MEM:-16MB}
+PG_MAINTENANCE_WORK_MEM=${PG_MAINTENANCE_WORK_MEM:-256MB}
+OSM2PGSQL_CACHE=${OSM2PGSQL_CACHE:-512}
+OSM2PGSQL_NUMPROC=${OSM2PGSQL_NUMPROC:-1}
+OSM2PGSQL_DATAFILE=${OSM2PGSQL_DATAFILE:-data.osm.pbf}
+EOF
+    chmod a+rw .env
+    export OSM2PGSQL_CACHE=${OSM2PGSQL_CACHE:-512}
+    export OSM2PGSQL_NUMPROC=${OSM2PGSQL_NUMPROC:-1}
+    export OSM2PGSQL_DATAFILE=${OSM2PGSQL_DATAFILE:-data.osm.pbf}
+  fi
+
+  # Importing data to a database
+  osm2pgsql -c -G --hstore -d osm ~/path/to/data.osm.pbf
+  osm2pgsql \
+  --cache $OSM2PGSQL_CACHE \
+  --number-processes $OSM2PGSQL_NUMPROC \
+  --hstore \
+  --database gis \
+  --slim \
+  -c \
+  -G \
+  --drop \
+  $OSM2PGSQL_DATAFILE
+  ;;
+
+kosmtik)
+  # Downloading needed shapefiles
+  # python scripts/get-shapefiles.py -n
+
+  # Creating default Kosmtik settings file
+  if [ ! -e ".kosmtik-config.yml" ]; then
+    cp /tmp/.kosmtik-config.yml .kosmtik-config.yml  
+  fi
+  export KOSMTIK_CONFIGPATH=".kosmtik-config.yml"
+
+  # Starting Kosmtik
+  kosmtik serve project.mml --host 0.0.0.0
+  # It needs Ctrl+C to be interrupted
+  ;;
+
+esac

--- a/scripts/tune-postgis.sh
+++ b/scripts/tune-postgis.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+export PGUSER="$POSTGRES_USER"
+
+"${psql[@]}" -c "ALTER SYSTEM SET work_mem='${PG_WORK_MEM:-16MB}';"
+"${psql[@]}" -c "ALTER SYSTEM SET maintenance_work_mem='${PG_MAINTENANCE_WORK_MEM:-256MB}';"


### PR DESCRIPTION
Taken from https://github.com/gravitystorm/openstreetmap-carto/blob/master/DOCKER.md

This guide makes setting up the database, mapnik, data and kosmtik much simpler, and without having to import data into the database running on the system.

See https://github.com/cyclosm/cyclosm-cartocss-style/blob/64461f470911da807bce852d5a8e106efabadeef/docs/DOCKER.md for textual documentation on getting started.