### PR TITLE
Building contours and z14 track width

### DIFF
--- a/amenities.mss
+++ b/amenities.mss
@@ -544,6 +544,16 @@
     }
   }
 
+  [feature = 'amenity_bench'][zoom >= 19] {
+    marker-file: url('symbols/openstreetmap-carto/amenity/bench.svg');
+    marker-fill: @man-made-icon;
+    marker-placement: interior;
+    marker-clip: false;
+    [access != ''][access != 'permissive'][access != 'yes'] {
+      marker-opacity: 0.33;
+    }
+  }
+
   [feature = 'aeroway_helipad'][zoom >= 16] {
     marker-file: url('symbols/openstreetmap-carto/helipad.16.svg');
     marker-placement: interior;

--- a/base.mss
+++ b/base.mss
@@ -204,10 +204,17 @@
 /* ---- BUILDINGS ---- */
 #buildings[zoom>=16] {
   polygon-fill: @building;
+  
+  /* Thin contour of buildings in mid zooms important for gray background areas */
+  line-color: darken(@building,10);
+  line-width: 0.3;
+  [zoom=17] {
+    line-width: 0.5;
+  }
 
   /* Render perimeter of buildings in high zooms */
   [zoom>=18] {
-    line-color: #b6b2af;
+    line-color: darken(@building,20);
     line-width: 0.75;
   }
 }

--- a/base.mss
+++ b/base.mss
@@ -23,7 +23,8 @@
   [type='landuse_cemetery'] {
     polygon-fill: @cemetery;
     [zoom >= 13] {
-      polygon-pattern-file: url('symbols/openstreetmap-carto/grave_yard_generic.svg');
+      polygon-pattern-file: url('symbols/openstreetmap-carto/grave_yard_generic_many.svg');
+      polygon-pattern-opacity: 0.15;
     }
   }
   [type='amenity_college']       { polygon-fill: @school; }

--- a/project.mml
+++ b/project.mml
@@ -1632,7 +1632,7 @@ Layer:
           COALESCE( -- order is important here
             'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,
             'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel', 'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery') THEN tourism ELSE NULL END,
-            'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
+            'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
             'shop_' || CASE WHEN tags->'service:bicycle:retail'='yes' OR tags->'service:bicycle:repair'='yes' OR tags->'service:bicycle:rental'='yes' OR tags->'service:bicycle:pump'='yes' OR tags->'service:bicycle:diy'='yes' THEN 'bicycle' ELSE CASE WHEN shop IN ('bicycle', 'bakery', 'beverage', 'convenience', 'convenience;gas', 'greengrocer', 'supermarket', 'pastry', 'sports') THEN bicycle ELSE NULL END END,
             'emergency_' || CASE WHEN tags->'emergency' IS NOT NULL then tags->'emergency' ELSE NULL END,
             'healthcare_' || CASE WHEN tags->'healthcare' IN ('clinic', 'hospital') THEN tags->'healthcare' ELSE NULL END,
@@ -1690,7 +1690,7 @@ Layer:
         WHERE aeroway IN ('helipad', 'aerodrome')
           OR tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel',
               'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery')
-          OR amenity IN ('atm', 'bank', 'bar', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
+          OR amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
                          'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food',
                          'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe',
                          'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath',
@@ -1763,7 +1763,7 @@ Layer:
           COALESCE( -- order is important here
             'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,
             'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel', 'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery') THEN tourism ELSE NULL END,
-            'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
+            'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
             'shop_' || CASE WHEN tags->'service:bicycle:retail'='yes' OR tags->'service:bicycle:repair'='yes' OR tags->'service:bicycle:rental'='yes' OR tags->'service:bicycle:pump'='yes' OR tags->'service:bicycle:diy'='yes' THEN 'bicycle' ELSE CASE WHEN shop IN ('bicycle', 'bakery', 'beverage', 'convenience', 'convenience;gas', 'greengrocer', 'supermarket', 'pastry', 'sports') THEN bicycle ELSE NULL END END,
             'emergency_' || CASE WHEN tags->'emergency' IS NOT NULL then tags->'emergency' ELSE NULL END,
             'healthcare_' || CASE WHEN tags->'healthcare' IN ('clinic', 'hospital') THEN tags->'healthcare' ELSE NULL END,
@@ -1835,7 +1835,7 @@ Layer:
         WHERE aeroway IN ('helipad', 'aerodrome')
           OR tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel',
               'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery')
-          OR amenity IN ('atm', 'bank', 'bar', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
+          OR amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
                          'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food',
                          'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe',
                          'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath',
@@ -1982,7 +1982,7 @@ Layer:
             COALESCE( -- order is important here
               'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel', 'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery') THEN tourism ELSE NULL END,
-              'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
+              'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
               'shop_' || CASE WHEN tags->'service:bicycle:retail'='yes' OR tags->'service:bicycle:repair'='yes' OR tags->'service:bicycle:rental'='yes' OR tags->'service:bicycle:pump'='yes' OR tags->'service:bicycle:diy'='yes' THEN 'bicycle' ELSE CASE WHEN shop IN ('bicycle', 'bakery', 'beverage', 'convenience', 'convenience;gas', 'greengrocer', 'supermarket', 'pastry', 'sports') THEN bicycle ELSE NULL END END,
               'emergency_' || CASE WHEN tags->'emergency' IS NOT NULL then tags->'emergency' ELSE NULL END,
               'healthcare_' || CASE WHEN tags->'healthcare' IN ('clinic', 'hospital') THEN tags->'healthcare' ELSE NULL END,
@@ -2040,7 +2040,7 @@ Layer:
           WHERE aeroway IN ('helipad', 'aerodrome')
             OR tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel',
                 'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery')
-            OR amenity IN ('atm', 'bank', 'bar', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
+            OR amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
                            'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food',
                            'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe',
                            'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath',
@@ -2129,7 +2129,7 @@ Layer:
             COALESCE( -- order is important here
               'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,
               'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel', 'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery') THEN tourism ELSE NULL END,
-              'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
+              'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
               'shop_' || CASE WHEN tags->'service:bicycle:retail'='yes' OR tags->'service:bicycle:repair'='yes' OR tags->'service:bicycle:rental'='yes' OR tags->'service:bicycle:pump'='yes' OR tags->'service:bicycle:diy'='yes' THEN 'bicycle' ELSE CASE WHEN shop IN ('bicycle', 'bakery', 'beverage', 'convenience', 'convenience;gas', 'greengrocer', 'supermarket', 'pastry', 'sports') THEN bicycle ELSE NULL END END,
               'emergency_' || CASE WHEN tags->'emergency' IS NOT NULL then tags->'emergency' ELSE NULL END,
               'healthcare_' || CASE WHEN tags->'healthcare' IN ('clinic', 'hospital') THEN tags->'healthcare' ELSE NULL END,
@@ -2201,7 +2201,7 @@ Layer:
           WHERE aeroway IN ('helipad', 'aerodrome')
             OR tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel',
                 'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery')
-            OR amenity IN ('atm', 'bank', 'bar', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
+            OR amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
                            'biergarten', 'cafe', 'car_wash', 'compressed_air', 'drinking_water', 'fast_food',
                            'ferry_terminal', 'food_court', 'fountain', 'hospital', 'ice_cream', 'internet_cafe',
                            'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath',

--- a/roads.mss
+++ b/roads.mss
@@ -195,7 +195,7 @@
 @rdz14_residential: 1;
 @rdz14_living_street: 1;
 @rdz14_service: 1;
-@rdz14_track: 1;
+@rdz14_track: 1.5;
 @rdz14_pedestrian: 1;
 @rdz14_bridleway: 0.25;
 @rdz14_path: 1;

--- a/roads.mss
+++ b/roads.mss
@@ -3133,6 +3133,7 @@
 
       // cyclocross
       line-dasharray: 5,2;
+      line-cap: butt;
       [zoom>=16] { line-dasharray: 10,4; }
       [zoom>=17] { line-dasharray: 20,8; }
       [surface_type='mtb'] {

--- a/symbols/openstreetmap-carto/amenity/bench.svg
+++ b/symbols/openstreetmap-carto/amenity/bench.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="14"
+   height="14"
+   viewBox="0 0 14 14"
+   id="svg2">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <rect
+     width="14"
+     height="14"
+     x="0"
+     y="0"
+     id="canvas"
+     style="fill:none;stroke:none;visibility:hidden" />
+  <path
+     d="M 1,5 C 0,5 0,6.5 1,6.5 l 12,0 C 14,6.5 14,5 13,5 L 1,5 z m 1,2 0,3 1.5,0 0,-3 L 2,7 z m 8.5,0 0,3 1.5,0 0,-3 -1.5,0 z"
+     id="bench" />
+</svg>

--- a/symbols/openstreetmap-carto/grave_yard_generic.svg
+++ b/symbols/openstreetmap-carto/grave_yard_generic.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg id="svg4" viewBox="0 0 32 32" height="32" width="32" version="1.1" xmlns="http://www.w3.org/2000/svg">
-  <rect style="visibility:hidden;fill:none;stroke:none" id="canvas" y="0" x="0" height="32" width="32"/>
-  <path style="fill-opacity: 1; stroke: none; stroke-width: 0.696311; fill: rgb(147, 153, 144);" d="m 6,6 v 4 H 4 v 1 h 8 V 10 H 10 V 6 C 10,3 8,3 8,3 8,3 6,3 6,6 Z" id="generic"/>
-</svg>

--- a/symbols/openstreetmap-carto/grave_yard_generic_many.svg
+++ b/symbols/openstreetmap-carto/grave_yard_generic_many.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg4"
+   viewBox="0 0 32 32"
+   height="32"
+   width="32"
+   version="1.1"
+   sodipodi:docname="grave_yard_generic_many.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata9">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="708"
+     id="namedview5"
+     showgrid="false"
+     inkscape:zoom="15.787109"
+     inkscape:cx="15.714957"
+     inkscape:cy="16"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <rect
+     style="visibility:hidden;fill:none;stroke:none"
+     id="canvas"
+     y="0"
+     x="0"
+     height="32"
+     width="32" />
+  <path
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.696311"
+     d="m 2,11 v 4 H 0 v 1 H 8 V 15 H 6 V 11 C 6,8 4,8 4,8 4,8 2,8 2,11 Z"
+     id="generic"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path847"
+     d="m 18,11 v 4 h -2 v 1 h 8 v -1 h -2 v -4 c 0,-3 -2,-3 -2,-3 0,0 -2,0 -2,3 z"
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.696311"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.696311"
+     d="m 2,27 v 4 H 0 v 1 H 8 V 31 H 6 V 27 C 6,24 4,24 4,24 4,24 2,24 2,27 Z"
+     id="generic-3" />
+  <path
+     id="path847-6"
+     d="m 18,27 v 4 h -2 v 1 h 8 v -1 h -2 v -4 c 0,-3 -2,-3 -2,-3 0,0 -2,0 -2,3 z"
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.696311"
+     inkscape:connector-curvature="0" />
+</svg>


### PR DESCRIPTION
Hello !

Now I can run cyclosm renderer, I tried to implement several minor changes.

Two opened issues :
* Render bench #377. Implemented exactly like defaut OSM map from zoom 19
* cycleway surface quality rendering is rounded #400

I pushed other cosmetic changes. Tell me If you don't want some of them, I can remove corresponding commits :

* Added very thin contour around building polygons in zooms 16/17 : contour had been removed for simplification but I found that even tiny contour was important  when land is gray

* Made cemetary pattern more dense, like OSM-fr style, because current pattern looks like POI icons.

* z14 track width was increased. Because it's the only zoom level where tracks and paths had the same width.

I hope it helps.

![cosmetic - cemetary pattern + buidding contour](https://user-images.githubusercontent.com/3080387/87851882-45b51d80-c8fd-11ea-9327-5e26ea0c0f4f.png)
![cosmetic - cycleway surface](https://user-images.githubusercontent.com/3080387/87851883-46e64a80-c8fd-11ea-9aae-74f863c34f38.png)
![cosmetic - z14 track width](https://user-images.githubusercontent.com/3080387/87851884-477ee100-c8fd-11ea-9943-8978fe33fcfd.png)