### PR TITLE
render leisure=track like path or cycleway

### DIFF
--- a/base.mss
+++ b/base.mss
@@ -154,6 +154,53 @@
   [type='natural_wood']          { polygon-fill: @wooded; }
 }
 
+/* Display linear leisure_track like an area. */
+#leisure_track[zoom >= 11] {
+  ::area_ouline {
+    line-cap: round;
+    line-join: round;
+    line-color: @track * 0.95;
+    line-width: 1 + @rdz12_track;
+    [zoom>=13] { line-width: 1 + @rdz13_track; }
+    [zoom>=14] { line-width: 1 + @rdz14_track; }
+    [zoom>=15] { line-width: 1 + @rdz15_track; }
+    [zoom>=16] { line-width: 1 + @rdz16_track; }
+    [zoom>=17] { line-width: 1 + @rdz17_track; }
+    [zoom>=18] { line-width: 1 + @rdz18_track; }
+  }
+
+  ::area {
+    line-cap: round;
+    line-join: round;
+    line-color: @track;
+    line-width: @rdz12_track;
+    [zoom>=13] { line-width: @rdz13_track; }
+    [zoom>=14] { line-width: @rdz14_track; }
+    [zoom>=15] { line-width: @rdz15_track; }
+    [zoom>=16] { line-width: @rdz16_track; }
+    [zoom>=17] { line-width: @rdz17_track; }
+    [zoom>=18] { line-width: @rdz18_track; }
+  }
+
+  /* larger because will contain cycleway line */
+  [sport='cycling'],
+  [sport='bmx'] {
+    ::area_ouline {
+      [zoom>=15] { line-width: 1 + 4*@rdz15_cycle; }
+      [zoom>=16] { line-width: 1 + 4*@rdz16_cycle; }
+      [zoom>=17] { line-width: 1 + 4*@rdz17_cycle; }
+      [zoom>=18] { line-width: 1 + 4*@rdz18_cycle; }
+    }
+
+    ::area {
+      [zoom>=15] { line-width: 4*@rdz15_cycle; }
+      [zoom>=16] { line-width: 4*@rdz16_cycle; }
+      [zoom>=17] { line-width: 4*@rdz17_cycle; }
+      [zoom>=18] { line-width: 4*@rdz18_cycle; }
+    }
+  }
+}
+
 #hillshade[zoom>=4] {
   raster-scaling: bilinear;
   raster-comp-op: multiply;

--- a/project.mml
+++ b/project.mml
@@ -461,11 +461,6 @@ Layer:
               ELSE NULL
             END,
             CASE
-              WHEN leisure='track' AND sport='cycling' THEN 'cycleway'
-              WHEN leisure='track' THEN 'path'
-              ELSE NULL
-            END,
-            CASE
               WHEN railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'railway'
               ELSE NULL
             END
@@ -581,9 +576,7 @@ Layer:
           END AS z_order
         FROM planet_osm_line
         WHERE (tunnel NOT IN ('no') OR covered NOT IN ('no') OR tags->'indoor' NOT IN ('no'))
-              AND (railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram')
-                OR highway IS NOT NULL
-                OR leisure = 'track' )
+              AND (railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') OR highway IS NOT NULL)
         ORDER BY z_order ASC
       ) AS data
   geometry: linestring
@@ -602,6 +595,22 @@ Layer:
   geometry: point
   properties:
     minzoom: 14
+- id: leisure_track
+  <<: *extents
+  Datasource:
+    <<: *osm2pgsql
+    table: |-
+      (
+        SELECT
+          way,
+          sport
+        FROM planet_osm_line
+        WHERE leisure = 'track'
+      ) AS data
+  geometry: linestring
+  properties:
+    cache-features: true
+    minzoom: 11
 - id: roads_high
   <<: *extents
   Datasource:
@@ -619,11 +628,6 @@ Layer:
               WHEN highway='footway' AND (bicycle='yes' OR bicycle='designated') THEN 'path'
               WHEN highway='bridleway' AND (bicycle='yes' OR bicycle='designated') THEN 'path'
               WHEN highway!='bus_guideway' THEN highway
-              ELSE NULL
-            END,
-            CASE
-              WHEN leisure='track' AND sport='cycling' THEN 'cycleway'
-              WHEN leisure='track' THEN 'path'
               ELSE NULL
             END,
             CASE
@@ -750,9 +754,7 @@ Layer:
             ELSE z_order
           END AS z_order
         FROM planet_osm_line
-        WHERE (highway IS NOT NULL
-                OR railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram')
-                OR leisure = 'track' )
+        WHERE (highway IS NOT NULL OR railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram'))
           AND (tunnel IS NULL OR tunnel = 'no')
           AND (bridge IS NULL OR bridge = 'no')
           AND (covered IS NULL OR covered = 'no')
@@ -885,11 +887,6 @@ Layer:
               ELSE NULL
             END,
             CASE
-              WHEN leisure='track' AND sport='cycling' THEN 'cycleway'
-              WHEN leisure='track' THEN 'path'
-              ELSE NULL
-            END,
-            CASE
               WHEN railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'railway'
               ELSE NULL
             END
@@ -1004,10 +1001,7 @@ Layer:
             ELSE z_order
           END AS z_order
         FROM planet_osm_line
-        WHERE bridge NOT IN ('no')
-          AND (railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram')
-                  OR highway IS NOT NULL
-                  OR leisure = 'track' )
+        WHERE bridge NOT IN ('no') AND (railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') OR highway IS NOT NULL)
         ORDER BY z_order ASC
       ) AS data
   geometry: linestring

--- a/project.mml
+++ b/project.mml
@@ -461,6 +461,11 @@ Layer:
               ELSE NULL
             END,
             CASE
+              WHEN leisure='track' AND sport='cycling' THEN 'cycleway'
+              WHEN leisure='track' THEN 'path'
+              ELSE NULL
+            END,
+            CASE
               WHEN railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'railway'
               ELSE NULL
             END
@@ -576,7 +581,9 @@ Layer:
           END AS z_order
         FROM planet_osm_line
         WHERE (tunnel NOT IN ('no') OR covered NOT IN ('no') OR tags->'indoor' NOT IN ('no'))
-              AND (railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') OR highway IS NOT NULL)
+              AND (railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram')
+                OR highway IS NOT NULL
+                OR leisure = 'track' )
         ORDER BY z_order ASC
       ) AS data
   geometry: linestring
@@ -612,6 +619,11 @@ Layer:
               WHEN highway='footway' AND (bicycle='yes' OR bicycle='designated') THEN 'path'
               WHEN highway='bridleway' AND (bicycle='yes' OR bicycle='designated') THEN 'path'
               WHEN highway!='bus_guideway' THEN highway
+              ELSE NULL
+            END,
+            CASE
+              WHEN leisure='track' AND sport='cycling' THEN 'cycleway'
+              WHEN leisure='track' THEN 'path'
               ELSE NULL
             END,
             CASE
@@ -738,7 +750,9 @@ Layer:
             ELSE z_order
           END AS z_order
         FROM planet_osm_line
-        WHERE (highway IS NOT NULL OR railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram'))
+        WHERE (highway IS NOT NULL
+                OR railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram')
+                OR leisure = 'track' )
           AND (tunnel IS NULL OR tunnel = 'no')
           AND (bridge IS NULL OR bridge = 'no')
           AND (covered IS NULL OR covered = 'no')
@@ -871,6 +885,11 @@ Layer:
               ELSE NULL
             END,
             CASE
+              WHEN leisure='track' AND sport='cycling' THEN 'cycleway'
+              WHEN leisure='track' THEN 'path'
+              ELSE NULL
+            END,
+            CASE
               WHEN railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') THEN 'railway'
               ELSE NULL
             END
@@ -985,7 +1004,10 @@ Layer:
             ELSE z_order
           END AS z_order
         FROM planet_osm_line
-        WHERE bridge NOT IN ('no') AND (railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram') OR highway IS NOT NULL)
+        WHERE bridge NOT IN ('no')
+          AND (railway IN ('light_rail', 'subway', 'narrow_gauge', 'rail', 'tram')
+                  OR highway IS NOT NULL
+                  OR leisure = 'track' )
         ORDER BY z_order ASC
       ) AS data
   geometry: linestring

--- a/roads.mss
+++ b/roads.mss
@@ -2117,18 +2117,19 @@
   }
 }
 /**/
-#leisure_track[zoom >= 11] {
-   line-cap: round;
-   line-join: round;
-   line-color: @track;
-
-   line-width: @rdz12_track;
-   [zoom>=13] { line-width: @rdz13_track; }
-   [zoom>=14] { line-width: @rdz14_track; }
-   [zoom>=15] { line-width: @rdz15_track; }
-   [zoom>=16] { line-width: @rdz16_track; }
-   [zoom>=17] { line-width: @rdz17_track; }
-   [zoom>=18] { line-width: @rdz18_track; }
+#leisure_track[zoom >= 15] {
+  [sport='cycling'],
+  [sport='bmx'] {
+    ::cycleway {
+      line-cap: round;
+      line-join: round;
+      line-color: @mixed-cycle-fill;
+      [zoom>=15] { line-width: 0.2 * @rdz15_cycle; }
+      [zoom>=16] { line-width: 0.4 * @rdz16_cycle; }
+      [zoom>=17] { line-width: 0.5 * @rdz17_cycle; }
+      [zoom>=18] { line-width: 0.6 * @rdz18_cycle; }
+    }
+  }
 }
 /**/
 #roads_high::inline[zoom>=11],

--- a/roads.mss
+++ b/roads.mss
@@ -2117,6 +2117,20 @@
   }
 }
 /**/
+#leisure_track[zoom >= 11] {
+   line-cap: round;
+   line-join: round;
+   line-color: @track;
+
+   line-width: @rdz12_track;
+   [zoom>=13] { line-width: @rdz13_track; }
+   [zoom>=14] { line-width: @rdz14_track; }
+   [zoom>=15] { line-width: @rdz15_track; }
+   [zoom>=16] { line-width: @rdz16_track; }
+   [zoom>=17] { line-width: @rdz17_track; }
+   [zoom>=18] { line-width: @rdz18_track; }
+}
+/**/
 #roads_high::inline[zoom>=11],
 #tunnel::inline[zoom>=11],
 #bridge::inline[zoom>=11] {

--- a/roads.mss
+++ b/roads.mss
@@ -2123,7 +2123,7 @@
     ::cycleway {
       line-cap: round;
       line-join: round;
-      line-color: @mixed-cycle-fill;
+      line-color: @bicycle-amenity;
       [zoom>=15] { line-width: 0.2 * @rdz15_cycle; }
       [zoom>=16] { line-width: 0.4 * @rdz16_cycle; }
       [zoom>=17] { line-width: 0.5 * @rdz17_cycle; }


### PR DESCRIPTION
Hello,
I noticed `leisure=track sport=cycling` are not rendered in cyclosm unless they are areas. But they can be ways : https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dtrack


Here is a proposal : `leisure=track sport=cycling` rendered as cycleway, and `leisure=track sport!=cycling` rendered as a path

![leisure_track cycling](https://user-images.githubusercontent.com/3080387/87873250-3945c900-c9c0-11ea-9edd-a2b1edf10cda.png)
![leisure_track default](https://user-images.githubusercontent.com/3080387/87873252-3a76f600-c9c0-11ea-93d3-95ce95d603d4.png)


EDIT (@Phyks): Fix #279.