### PR TITLE
Rail and protected areas rework

### DIFF
--- a/admin.mss
+++ b/admin.mss
@@ -224,28 +224,41 @@ overlapping borders correctly.
   }
 }
 
-#protected-areas::area[zoom <= 11] {
+#protected-areas::area[zoom < 11] {
   polygon-fill: darken(@wooded,25%);
 
   opacity: 0.15;
   comp-op: darken; /* In case of two area overlapping this avoid to have a darker area. */
 }
 
-#protected-areas::outline[zoom >= 7] {
-  background/line-color: lighten(@wooded,15%);
-  line-color: darken(@wooded,30%);
-  line-dasharray: 6,6;
+#protected-areas::largeline[zoom >= 11] {
+  line-comp-op: multiply;
+  line-color: @wooded;
+  line-join: round;
+  line-cap: round;
 
-  [zoom=7] { line-width: 1.2;     background/line-width: 2.4;  }
-  [zoom=8] { line-width: 1.4;     background/line-width: 2.8;  }
-  [zoom=9] { line-width: 1.5;     background/line-width: 3.0;  }
-  [zoom=10] { line-width: 1.6;    background/line-width: 3.2;  background/line-offset: -0.8;}
-  [zoom=11] { line-width: 1.8;    background/line-width: 3.6;  background/line-offset: -0.9;}
-  [zoom>=12] { line-width: 2.0;   background/line-width: 4.0;  background/line-offset: -1;}
-  [zoom>=14] { line-width: 3.0;   background/line-width: 6.0;  background/line-offset: -1.5;}
+  line-opacity: 0.2;
+  line-width: 8; line-offset: -4;
+}
 
-  opacity: 0.7;
-  comp-op: darken; /* Fusion with admin bordes. */
+#protected-areas::mediumline[zoom >= 7] {
+  line-comp-op: multiply;
+  line-color: @wooded;
+  line-join: round;
+  line-cap: round;
+
+  line-opacity: 0.2;
+  line-width: 4; line-offset: -2;
+}
+
+#protected-areas::narrowline[zoom >= 7] {
+  line-comp-op: multiply;
+  line-color: @wooded;
+  line-join: round;
+  line-cap: round;
+
+  line-opacity: 0.1;
+  line-width: 1.0; line-offset: -0.5;
 }
 
 #protected-areas-text[zoom >= 13][way_pixels > 192000] {

--- a/labels.mss
+++ b/labels.mss
@@ -13,14 +13,15 @@
 #highway_area_label,
 #area_label {
   // Bring in labels gradually as one zooms in, bases on polygon area
-  [zoom>=10][area>102400000],
-  [zoom>=11][area>25600000],
-  [zoom>=13][area>1600000],
-  [zoom>=14][area>320000],
-  [zoom>=15][area>80000],
-  [zoom>=16][area>20000],
-  [zoom>=17][area>5000],
-  [zoom>=18][area>=0] {
+  [zoom=10][area>102400000],
+  [zoom=11][area>51200000],
+  [zoom=12][area>25600000],
+  [zoom=13][area>1280000][area<256000000],
+  [zoom=14][area>320000] [area<64000000],
+  [zoom=15][area>80000]  [area<16000000],
+  [zoom=16][area>20000]  [area<4000000],
+  [zoom=17][area>5000]   [area<100000],
+  [zoom>=18]             [area<25000] {
     text-name: "[name]";
     text-halo-radius: 1.5;
     text-face-name:@sans;
@@ -29,6 +30,7 @@
     text-fill: #888;
     text-halo-fill: @standard-halo-fill;
     text-placement: interior;
+
     // Specific style overrides for different types of areas:
     [type='forest'],
     [type='wood'],
@@ -72,29 +74,31 @@
       text-fill: @military * 0.6;
       text-face-name: @sans_italic;
     }
-  }
-  [zoom=15][area>1600000],
-  [zoom=16][area>80000],
-  [zoom=17][area>20000],
-  [zoom=18][area>5000] {
-    text-name: "[name]";
-    text-size: 13;
-    text-wrap-width: 60;
-    text-character-spacing: 1;
-    text-halo-radius: 2;
-  }
-  [zoom=16][area>1600000],
-  [zoom=17][area>80000],
-  [zoom=18][area>20000] {
-    text-size: 15;
-    text-character-spacing: 2;
-    text-wrap-width: 120;
-  }
-  [zoom>=17][area>1600000],
-  [zoom>=18][area>80000] {
-    text-size: 20;
-    text-character-spacing: 3;
-    text-wrap-width: 180;
+
+    // text size adjustement regarding area size:
+    [zoom=15][area>1600000],
+    [zoom=16][area>80000],
+    [zoom=17][area>20000],
+    [zoom=18][area>5000] {
+        text-name: "[name]";
+        text-size: 13;
+        text-wrap-width: 60;
+        text-character-spacing: 1;
+        text-halo-radius: 2;
+    }
+    [zoom=16][area>1600000],
+    [zoom=17][area>80000],
+    [zoom=18][area>20000] {
+        text-size: 15;
+        text-character-spacing: 2;
+        text-wrap-width: 120;
+    }
+    [zoom>=17][area>1600000],
+    [zoom>=18][area>80000] {
+        text-size: 20;
+        text-character-spacing: 3;
+        text-wrap-width: 180;
+    }
   }
 }
 

--- a/roads.mss
+++ b/roads.mss
@@ -62,7 +62,7 @@
 
         line-color: @rail-line;
         line-cap: butt;
-        line-dasharray: 1,8;
+        line-dasharray: 0,4,1,4; /* start with space to avoid dense pattern on very short ways */
         line-width: 2;
         [zoom >= 9] { line-width: 3; }
     }
@@ -3436,8 +3436,11 @@
 
         line-color: @rail-line;
         line-cap: butt;
-        line-dasharray: 1,4;
-        [zoom>=14] { line-dasharray: 1,8; }
+
+        /* hatches: start with space to avoid dense pattern on very short ways */
+        line-dasharray: 0,2,1,2;
+        [zoom>=14] { line-dasharray: 0,4,1,4; }
+
         line-width: 3;
         [zoom>=19] { line-width: 6; }
     }

--- a/roads.mss
+++ b/roads.mss
@@ -5,52 +5,6 @@
 // At lower zoomlevels, just show major automobile routes: motorways
 // and trunks.
 
-#roads_low[type!='railway'][zoom>=5][zoom<=8] {
-  line-color: @motorway-trunk-fill;
-
-  [type='motorway'][bicycle='yes'] {
-    line-color: @motorway-trunk-cycle-fill;
-  }
-
-  line-width: 0.3;
-  [zoom >= 6] {
-    line-width: 0.4;
-  }
-  [zoom >= 7] {
-    line-width: 0.6;
-  }
-  [zoom >= 8] {
-    line-width: 0.8;
-  }
-}
-
-// At mid-level scales start to show primary and secondary routes
-// as well.
-
-#roads_med[type!='railway'][zoom >= 9][zoom<=10] {
-  line-color: @motorway-trunk-fill;
-
-  [type='motorway'][can_bicycle='yes'] {
-    line-color: @motorway-trunk-cycle-fill;
-  }
-  [type='primary'] {
-    line-color: @primary-case;
-  }
-  [type='secondary'] {
-    line-color: @standard-case;
-  }
-
-  line-width: 1;
-  [type='secondary']
-  {
-    line-width: 0.6;
-
-    [zoom >= 10] {
-      line-width: 1;
-    }
-  }
-}
-
 
 #roads_low[zoom=8],
 #roads_med[zoom>=9][zoom<=10] {
@@ -68,16 +22,58 @@
     }
 }
 
-#roads_low[zoom>=5][zoom<=8],
-#roads_med[zoom>=9][zoom<=10] {
-    [type='railway']::rail_line {
-        line-color: @rail-line;
-        line-join: round;
-        line-width: 0.3;
-        [zoom >= 6] { line-width: 0.4; }
-        [zoom >= 7] { line-width: 0.6; }
-        [zoom >= 8] { line-width: 0.7; }
+#roads_low[zoom>=5][zoom<=8] {
+  line-color: @motorway-trunk-fill;
+
+  [type='motorway'][bicycle='yes'] {
+    line-color: @motorway-trunk-cycle-fill;
+  }
+
+  [type='railway'] {
+    line-color: @rail-line;
+  }
+
+  line-width: 0.3;
+  [zoom >= 6] {
+    line-width: 0.4;
+  }
+  [zoom >= 7] {
+    line-width: 0.6;
+  }
+  [zoom >= 8] {
+    line-width: 0.8;
+  }
+}
+
+// At mid-level scales start to show primary and secondary routes
+// as well.
+
+#roads_med[zoom >= 9][zoom<=10] {
+  line-color: @motorway-trunk-fill;
+
+  [type='motorway'][can_bicycle='yes'] {
+    line-color: @motorway-trunk-cycle-fill;
+  }
+  [type='primary'] {
+    line-color: @primary-case;
+  }
+  [type='secondary'] {
+    line-color: @standard-case;
+  }
+
+  [type='railway'] {
+    line-color: @rail-line;
+  }
+
+  line-width: 1;
+  [type='secondary']
+  {
+    line-width: 0.6;
+
+    [zoom >= 10] {
+      line-width: 1;
     }
+  }
 }
 
 // At higher levels the roads become more complex. We're now showing
@@ -117,7 +113,7 @@
 @rdz11_track: 0.25;
 @rdz11_path: 0.30;
 @rdz11_cycle: 0.5;
-@rdz11_railway: 0.8;
+@rdz11_railway: 0.5;
 // Border width (one side of the road only)
 @rdz11_motorway_trunk_outline: 1;
 @rdz11_primary_outline: 0.8;
@@ -150,7 +146,7 @@
 @rdz12_pedestrian: 0.5;
 @rdz12_path: 0.5;
 @rdz12_cycle: 0.8;
-@rdz12_railway: 0.8;
+@rdz12_railway: 0.5;
 // Border width (one side of the road only)
 @rdz12_motorway_trunk_outline: 1;
 @rdz12_primary_outline: 1;
@@ -186,7 +182,7 @@
 @rdz13_footway: 0.20;
 @rdz13_steps: 0.3;
 @rdz13_cycle: 1;
-@rdz13_railway: 0.8;
+@rdz13_railway: 0.5;
 // Border width (one side of the road only)
 @rdz13_motorway_trunk_outline: 1;
 @rdz13_primary_outline: 1;
@@ -223,7 +219,7 @@
 @rdz14_footway: 0.25;
 @rdz14_steps: 0.5;
 @rdz14_cycle: 2;
-@rdz14_railway: 0.8;
+@rdz14_railway: 0.6;
 @rdz14_turning_circle_marker: 1.1;
 // Border width
 // Border width (one side of the road only)
@@ -262,7 +258,7 @@
 @rdz15_footway: 0.5;
 @rdz15_steps: 0.8;
 @rdz15_cycle: 2;
-@rdz15_railway: 1;
+@rdz15_railway: 0.8;
 @rdz15_turning_circle_marker: 1.65;
 // Border width (one side of the road only)
 @rdz15_motorway_trunk_outline: 1.25;
@@ -300,7 +296,7 @@
 @rdz16_footway: 0.75;
 @rdz16_steps: 1.25;
 @rdz16_cycle: 2;
-@rdz16_railway: 1.1;
+@rdz16_railway: 1;
 @rdz16_turning_circle_marker: 6;
 // Border width (one side of the road only)
 @rdz16_motorway_trunk_outline: 1.25;
@@ -338,7 +334,7 @@
 @rdz17_footway: 1.5;
 @rdz17_steps: 3;
 @rdz17_cycle: 3;
-@rdz17_railway: 1.1;
+@rdz17_railway: 1;
 @rdz17_turning_circle_marker: 15;
 // Border width (one side of the road only)
 @rdz17_motorway_trunk_outline: 1.5;
@@ -377,7 +373,7 @@
 @rdz18_footway: 2;
 @rdz18_steps: 3.5;
 @rdz18_cycle: 4;
-@rdz18_railway: 1.1;
+@rdz18_railway: 1;
 @rdz18_turning_circle_marker: 21;
 // Border width (one side of the road only)
 @rdz18_motorway_trunk_outline: 2;
@@ -396,6 +392,29 @@
 @rdz18_steps_outline: 1;
 @rdz18_line_bridge_outline: 1;  // cycleway, footway, bridleway, path on bridges
 
+// ---- Rail background with hatches -------------------------
+
+#roads_high[zoom>=11],
+#bridge[zoom>=11] {
+    [type='railway']::rail_perpendicular {
+
+        /* background: to avoid weird pattern when many tracks are overlapping */
+        [zoom<14] {
+            background/line-color: @land;
+            background/line-width: 3;
+        }
+
+        line-color: @rail-line;
+        line-cap: butt;
+
+        /* hatches: start with space to avoid dense pattern on very short ways */
+        line-dasharray: 0,2,1,2;
+        [zoom>=14] { line-dasharray: 0,4,1,4; }
+
+        line-width: 3;
+        [zoom>=19] { line-width: 6; }
+    }
+}
 
 // ---- Casing -----------------------------------------------
 
@@ -3422,28 +3441,6 @@
       line-width: @rdz18_path*2;
     }
   }
-}
-
-#roads_high[zoom>=11],
-#bridge[zoom>=11] {
-    [type='railway']::rail_perpendicular {
-
-        /* background: to avoid weird pattern when many tracks are overlapping */
-        [zoom<14] {
-            background/line-color: @land;
-            background/line-width: 3;
-        }
-
-        line-color: @rail-line;
-        line-cap: butt;
-
-        /* hatches: start with space to avoid dense pattern on very short ways */
-        line-dasharray: 0,2,1,2;
-        [zoom>=14] { line-dasharray: 0,4,1,4; }
-
-        line-width: 3;
-        [zoom>=19] { line-width: 6; }
-    }
 }
 
 

--- a/roads.mss
+++ b/roads.mss
@@ -5,15 +5,11 @@
 // At lower zoomlevels, just show major automobile routes: motorways
 // and trunks.
 
-#roads_low[zoom>=5][zoom<=8] {
+#roads_low[type!='railway'][zoom>=5][zoom<=8] {
   line-color: @motorway-trunk-fill;
 
   [type='motorway'][bicycle='yes'] {
     line-color: @motorway-trunk-cycle-fill;
-  }
-
-  [type='railway'] {
-    line-color: @rail-line;
   }
 
   line-width: 0.3;
@@ -31,7 +27,7 @@
 // At mid-level scales start to show primary and secondary routes
 // as well.
 
-#roads_med[zoom >= 9] {
+#roads_med[type!='railway'][zoom >= 9][zoom<=10] {
   line-color: @motorway-trunk-fill;
 
   [type='motorway'][can_bicycle='yes'] {
@@ -44,10 +40,6 @@
     line-color: @standard-case;
   }
 
-  [type='railway'] {
-    line-color: @rail-line;
-  }
-
   line-width: 1;
   [type='secondary']
   {
@@ -57,6 +49,35 @@
       line-width: 1;
     }
   }
+}
+
+
+#roads_low[zoom=8],
+#roads_med[zoom>=9][zoom<=10] {
+    [type='railway']::rail_perpendicular {
+
+        /* background: to avoid weird pattern when many tracks are overlapping */
+        background/line-color: @land;
+        background/line-width: 3;
+
+        line-color: @rail-line;
+        line-cap: butt;
+        line-dasharray: 1,8;
+        line-width: 2;
+        [zoom >= 9] { line-width: 3; }
+    }
+}
+
+#roads_low[zoom>=5][zoom<=8],
+#roads_med[zoom>=9][zoom<=10] {
+    [type='railway']::rail_line {
+        line-color: @rail-line;
+        line-join: round;
+        line-width: 0.3;
+        [zoom >= 6] { line-width: 0.4; }
+        [zoom >= 7] { line-width: 0.6; }
+        [zoom >= 8] { line-width: 0.7; }
+    }
 }
 
 // At higher levels the roads become more complex. We're now showing
@@ -96,7 +117,7 @@
 @rdz11_track: 0.25;
 @rdz11_path: 0.30;
 @rdz11_cycle: 0.5;
-@rdz11_railway: 0.5;
+@rdz11_railway: 0.8;
 // Border width (one side of the road only)
 @rdz11_motorway_trunk_outline: 1;
 @rdz11_primary_outline: 0.8;
@@ -129,7 +150,7 @@
 @rdz12_pedestrian: 0.5;
 @rdz12_path: 0.5;
 @rdz12_cycle: 0.8;
-@rdz12_railway: 0.5;
+@rdz12_railway: 0.8;
 // Border width (one side of the road only)
 @rdz12_motorway_trunk_outline: 1;
 @rdz12_primary_outline: 1;
@@ -165,7 +186,7 @@
 @rdz13_footway: 0.20;
 @rdz13_steps: 0.3;
 @rdz13_cycle: 1;
-@rdz13_railway: 0.5;
+@rdz13_railway: 0.8;
 // Border width (one side of the road only)
 @rdz13_motorway_trunk_outline: 1;
 @rdz13_primary_outline: 1;
@@ -202,7 +223,7 @@
 @rdz14_footway: 0.25;
 @rdz14_steps: 0.5;
 @rdz14_cycle: 2;
-@rdz14_railway: 0.6;
+@rdz14_railway: 0.8;
 @rdz14_turning_circle_marker: 1.1;
 // Border width
 // Border width (one side of the road only)
@@ -241,7 +262,7 @@
 @rdz15_footway: 0.5;
 @rdz15_steps: 0.8;
 @rdz15_cycle: 2;
-@rdz15_railway: 0.8;
+@rdz15_railway: 1;
 @rdz15_turning_circle_marker: 1.65;
 // Border width (one side of the road only)
 @rdz15_motorway_trunk_outline: 1.25;
@@ -279,7 +300,7 @@
 @rdz16_footway: 0.75;
 @rdz16_steps: 1.25;
 @rdz16_cycle: 2;
-@rdz16_railway: 1;
+@rdz16_railway: 1.1;
 @rdz16_turning_circle_marker: 6;
 // Border width (one side of the road only)
 @rdz16_motorway_trunk_outline: 1.25;
@@ -317,7 +338,7 @@
 @rdz17_footway: 1.5;
 @rdz17_steps: 3;
 @rdz17_cycle: 3;
-@rdz17_railway: 1;
+@rdz17_railway: 1.1;
 @rdz17_turning_circle_marker: 15;
 // Border width (one side of the road only)
 @rdz17_motorway_trunk_outline: 1.5;
@@ -356,7 +377,7 @@
 @rdz18_footway: 2;
 @rdz18_steps: 3.5;
 @rdz18_cycle: 4;
-@rdz18_railway: 1;
+@rdz18_railway: 1.1;
 @rdz18_turning_circle_marker: 21;
 // Border width (one side of the road only)
 @rdz18_motorway_trunk_outline: 2;
@@ -3403,6 +3424,25 @@
   }
 }
 
+#roads_high[zoom>=11],
+#bridge[zoom>=11] {
+    [type='railway']::rail_perpendicular {
+
+        /* background: to avoid weird pattern when many tracks are overlapping */
+        [zoom<14] {
+            background/line-color: @land;
+            background/line-width: 3;
+        }
+
+        line-color: @rail-line;
+        line-cap: butt;
+        line-dasharray: 1,4;
+        [zoom>=14] { line-dasharray: 1,8; }
+        line-width: 3;
+        [zoom>=19] { line-width: 6; }
+    }
+}
+
 
 #roads_high::rail_line[zoom>=11],
 #bridge::rail_line[zoom>=11] {
@@ -3430,38 +3470,6 @@
     }
     [zoom>=18] {
       line-width: @rdz18_railway;
-    }
-  }
-}
-
-#roads_high::rail_line2[zoom>=11],
-#bridge::rail_line2[zoom>=11] {
-  [type='railway'] {
-    line-color: @rail-line;
-    line-dasharray: 1,4;
-    [zoom>=14] { line-dasharray: 1,8; }
-
-    line-width: @rdz11_railway*3;
-    [zoom>=12] {
-      line-width: @rdz12_railway*3;
-    }
-    [zoom>=13] {
-      line-width: @rdz13_railway*3;
-    }
-    [zoom>=14] {
-      line-width: @rdz14_railway*3;
-    }
-    [zoom>=15] {
-      line-width: @rdz15_railway*3;
-    }
-    [zoom>=16] {
-      line-width: @rdz16_railway*3;
-    }
-    [zoom>=17] {
-      line-width: @rdz17_railway*3;
-    }
-    [zoom>=18] {
-      line-width: @rdz18_railway*3;
     }
   }
 }


### PR DESCRIPTION
Hello,

I made rails more visible (for issue #403) by adding perpendicular hatches.
I changed protected areas contour (for issue #396)
and added maximum area size for their text display condition (for issue #375)

![rail+protected z8](https://user-images.githubusercontent.com/3080387/87874549-15d44b80-c9cb-11ea-9ef1-278f0a60dc07.png)
![rail+protected z10](https://user-images.githubusercontent.com/3080387/87874550-179e0f00-c9cb-11ea-9609-0d00b7c288c9.png)
![rail+protected z12](https://user-images.githubusercontent.com/3080387/87874552-18cf3c00-c9cb-11ea-97af-23eac7320b7a.png)
![rail+protected z15](https://user-images.githubusercontent.com/3080387/87874553-1967d280-c9cb-11ea-86ae-7b73e32946bc.png)

EDIT (@Phyks): Fix #403, fix #396, fix #375.