### PR TITLE
Fixes to the nomotor road style

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -475,12 +475,16 @@ Layer:
             ELSE NULL
           END AS maxspeed_kmh,
           CASE
-            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            -- goods and hgv are not technically children of motorcar, but the motorcar restriction is often intended to cover cars and all larger vehicles
-            WHEN COALESCE(tags->'goods', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            WHEN COALESCE(tags->'hgv', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') NOT IN ('no', 'private') THEN 'yes'
+            -- goods and hgv don't need COALESCE chains, because the next step would be motorcar, which is checked above 
+            WHEN tags->'goods' NOT IN ('no', 'private') THEN 'yes'
+            WHEN tags->'hgv' NOT IN ('no', 'private') THEN 'yes'
+            -- moped and mofa are not checked, since most countries that have separate access controls for them treat them as quasi-bicycles
+            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') NOT IN ('no', 'private') THEN 'yes'
             -- TODO: style psv-only roads slightly differently
+            -- bus only needs to have its COALESCE chain go up to psv, because the next step would be motorcar, which is checked above
+            WHEN COALESCE(tags->'bus', tags->'psv') NOT IN ('no', 'private') THEN 'psv'
+            WHEN tags->'taxi' NOT IN ('no', 'private') THEN 'psv'
             ELSE 'no'
           END AS motor_vehicle,
           CASE
@@ -628,12 +632,16 @@ Layer:
             ELSE NULL
           END AS maxspeed_kmh,
           CASE
-            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            -- goods and hgv are not technically children of motorcar, but the motorcar restriction is often intended to cover cars and all larger vehicles
-            WHEN COALESCE(tags->'goods', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            WHEN COALESCE(tags->'hgv', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') NOT IN ('no', 'private') THEN 'yes'
+            -- goods and hgv don't need COALESCE chains, because the next step would be motorcar, which is checked above 
+            WHEN tags->'goods' NOT IN ('no', 'private') THEN 'yes'
+            WHEN tags->'hgv' NOT IN ('no', 'private') THEN 'yes'
+            -- moped and mofa are not checked, since most countries that have separate access controls for them treat them as quasi-bicycles
+            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') NOT IN ('no', 'private') THEN 'yes'
             -- TODO: style psv-only roads slightly differently
+            -- bus only needs to have its COALESCE chain go up to psv, because the next step would be motorcar, which is checked above
+            WHEN COALESCE(tags->'bus', tags->'psv') NOT IN ('no', 'private') THEN 'psv'
+            WHEN tags->'taxi' NOT IN ('no', 'private') THEN 'psv'
             ELSE 'no'
           END AS motor_vehicle,
           CASE
@@ -885,12 +893,16 @@ Layer:
             ELSE NULL
           END AS maxspeed_kmh,
           CASE
-            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            -- goods and hgv are not technically children of motorcar, but the motorcar restriction is often intended to cover cars and all larger vehicles
-            WHEN COALESCE(tags->'goods', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            WHEN COALESCE(tags->'hgv', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
-            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') NOT IN ('no', 'private') THEN 'yes'
+            -- goods and hgv don't need COALESCE chains, because the next step would be motorcar, which is checked above 
+            WHEN tags->'goods' NOT IN ('no', 'private') THEN 'yes'
+            WHEN tags->'hgv' NOT IN ('no', 'private') THEN 'yes'
+            -- moped and mofa are not checked, since most countries that have separate access controls for them treat them as quasi-bicycles
+            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') NOT IN ('no', 'private') THEN 'yes'
             -- TODO: style psv-only roads slightly differently
+            -- bus only needs to have its COALESCE chain go up to psv, because the next step would be motorcar, which is checked above
+            WHEN COALESCE(tags->'bus', tags->'psv') NOT IN ('no', 'private') THEN 'psv'
+            WHEN tags->'taxi' NOT IN ('no', 'private') THEN 'psv'
             ELSE 'no'
           END AS motor_vehicle,
           CASE

--- a/project.mml
+++ b/project.mml
@@ -476,11 +476,11 @@ Layer:
           END AS maxspeed_kmh,
           CASE
             WHEN (
-              tags->'psv' != 'no' OR tags->'motorcar' != 'no' OR tags->'bus' != 'no'
+              tags->'psv' != 'no' OR motorcar != 'no' OR tags->'bus' != 'no'
               OR tags->'motor_vehicle' != 'no'
               OR tags->'vehicle' != 'no'
               ) THEN 'yes'
-            WHEN tags->'psv' IS NULL AND tags->'motorcar' IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
+            WHEN tags->'psv' IS NULL AND motorcar IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
             ELSE 'no'
           END AS motor_vehicle,
           CASE
@@ -629,11 +629,11 @@ Layer:
           END AS maxspeed_kmh,
           CASE
             WHEN (
-              tags->'psv' != 'no' OR tags->'motorcar' != 'no' OR tags->'bus' != 'no'
+              tags->'psv' != 'no' OR motorcar != 'no' OR tags->'bus' != 'no'
               OR tags->'motor_vehicle' != 'no'
               OR tags->'vehicle' != 'no'
               ) THEN 'yes'
-            WHEN tags->'psv' IS NULL AND tags->'motorcar' IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
+            WHEN tags->'psv' IS NULL AND motorcar IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
             ELSE 'no'
           END AS motor_vehicle,
           CASE
@@ -886,11 +886,11 @@ Layer:
           END AS maxspeed_kmh,
           CASE
             WHEN (
-              tags->'psv' != 'no' OR tags->'motorcar' != 'no' OR tags->'bus' != 'no'
+              tags->'psv' != 'no' OR motorcar != 'no' OR tags->'bus' != 'no'
               OR tags->'motor_vehicle' != 'no'
               OR tags->'vehicle' != 'no'
               ) THEN 'yes'
-            WHEN tags->'psv' IS NULL AND tags->'motorcar' IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
+            WHEN tags->'psv' IS NULL AND motorcar IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
             ELSE 'no'
           END AS motor_vehicle,
           CASE

--- a/project.mml
+++ b/project.mml
@@ -475,12 +475,12 @@ Layer:
             ELSE NULL
           END AS maxspeed_kmh,
           CASE
-            WHEN (
-              tags->'psv' != 'no' OR motorcar != 'no' OR tags->'bus' != 'no'
-              OR tags->'motor_vehicle' != 'no'
-              OR tags->'vehicle' != 'no'
-              ) THEN 'yes'
-            WHEN tags->'psv' IS NULL AND motorcar IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
+            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            -- goods and hgv are not technically children of motorcar, but the motorcar restriction is often intended to cover cars and all larger vehicles
+            WHEN COALESCE(tags->'goods', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(tags->'hgv', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            -- TODO: style psv-only roads slightly differently
             ELSE 'no'
           END AS motor_vehicle,
           CASE
@@ -628,12 +628,12 @@ Layer:
             ELSE NULL
           END AS maxspeed_kmh,
           CASE
-            WHEN (
-              tags->'psv' != 'no' OR motorcar != 'no' OR tags->'bus' != 'no'
-              OR tags->'motor_vehicle' != 'no'
-              OR tags->'vehicle' != 'no'
-              ) THEN 'yes'
-            WHEN tags->'psv' IS NULL AND motorcar IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
+            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            -- goods and hgv are not technically children of motorcar, but the motorcar restriction is often intended to cover cars and all larger vehicles
+            WHEN COALESCE(tags->'goods', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(tags->'hgv', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            -- TODO: style psv-only roads slightly differently
             ELSE 'no'
           END AS motor_vehicle,
           CASE
@@ -885,12 +885,12 @@ Layer:
             ELSE NULL
           END AS maxspeed_kmh,
           CASE
-            WHEN (
-              tags->'psv' != 'no' OR motorcar != 'no' OR tags->'bus' != 'no'
-              OR tags->'motor_vehicle' != 'no'
-              OR tags->'vehicle' != 'no'
-              ) THEN 'yes'
-            WHEN tags->'psv' IS NULL AND motorcar IS NULL AND tags->'bus' IS NULL AND tags->'motor_vehicle' IS NULL AND tags->'vehicle' IS NULL AND (access != 'no' OR access IS NULL) THEN 'yes'
+            WHEN COALESCE(motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            -- goods and hgv are not technically children of motorcar, but the motorcar restriction is often intended to cover cars and all larger vehicles
+            WHEN COALESCE(tags->'goods', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(tags->'hgv', motorcar, tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            WHEN COALESCE(tags->'motorcycle', tags->'motor_vehicle', tags->'vehicle', access, 'yes') != 'no' THEN 'yes'
+            -- TODO: style psv-only roads slightly differently
             ELSE 'no'
           END AS motor_vehicle,
           CASE


### PR DESCRIPTION
Update tags->'motorcar' to just motorcar.

motorcar is defined as a top-level field in planet_osm_line, and so not actually available in tags. This was breaking the nomotor styling for roads with motorcar=no.

EDIT (@Phyks): Fix #406.