### PR TITLE
Treat use_sidepath as no

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -529,7 +529,7 @@ Layer:
             ELSE NULL
           END AS cycleway_right_oneway,
           CASE
-            WHEN bicycle IN ('no', 'private') THEN 'no'
+            WHEN bicycle IN ('no', 'private', 'use_sidepath') THEN 'no'
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway IN ('motorway', 'motorway_link') THEN 'no'
@@ -682,7 +682,7 @@ Layer:
             ELSE NULL
           END AS cycleway_right_oneway,
           CASE
-            WHEN bicycle IN ('no', 'private') THEN 'no'
+            WHEN bicycle IN ('no', 'private', 'use_sidepath') THEN 'no'
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway IN ('motorway', 'motorway_link') THEN 'no'
@@ -765,7 +765,7 @@ Layer:
             END
           ) AS type,
           CASE
-            WHEN bicycle IN ('no', 'private') THEN 'no'
+            WHEN bicycle IN ('no', 'private', 'use_sidepath') THEN 'no'
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway NOT IN ('motorway', 'motorway_link') AND tags->'vehicle' IN ('no', 'private') THEN 'no'
@@ -939,7 +939,7 @@ Layer:
             ELSE NULL
           END AS cycleway_right_oneway,
           CASE
-            WHEN bicycle IN ('no', 'private') THEN 'no'
+            WHEN bicycle IN ('no', 'private', 'use_sidepath') THEN 'no'
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway IN ('motorway', 'motorway_link') THEN 'no'


### PR DESCRIPTION
bicycle=use_sidepath denotes that cycling on the main road is legally forbidden, and that cyclists *must* use the sidepath. So it makes sense to render the same as bicycle=no, since it's just a specialisation that hints routers to look for a separate cycleway.