### PR TITLE
Fix default access restrictions of highway=pedestrian, close #393.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Render `surface=unpaved` as unknown surface + minor fixes for surfaces.
     See #367.
 * Fix correct default access restrictions for `highway=pedestrian`. See #393.
+* Consider a way with `bicycle=dismount` is equivalent tagging to
+    `bicycle=no`.
 
 
 ## v0.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Render `public_transport=platform` + `shelter=yes` as shelter. See #378.
 * Render `surface=unpaved` as unknown surface + minor fixes for surfaces.
     See #367.
+* Fix correct default access restrictions for `highway=pedestrian`. See #393.
 
 
 ## v0.3.6

--- a/project.mml
+++ b/project.mml
@@ -529,7 +529,7 @@ Layer:
             ELSE NULL
           END AS cycleway_right_oneway,
           CASE
-            WHEN bicycle IN ('no', 'private', 'use_sidepath') THEN 'no'
+            WHEN bicycle IN ('no', 'dismount', 'private', 'use_sidepath') THEN 'no'
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway IN ('motorway', 'motorway_link') THEN 'no'
@@ -686,7 +686,7 @@ Layer:
             ELSE NULL
           END AS cycleway_right_oneway,
           CASE
-            WHEN bicycle IN ('no', 'private', 'use_sidepath') THEN 'no'
+            WHEN bicycle IN ('no', 'dismount', 'private', 'use_sidepath') THEN 'no'
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway IN ('motorway', 'motorway_link') THEN 'no'
@@ -771,7 +771,7 @@ Layer:
             END
           ) AS type,
           CASE
-            WHEN bicycle IN ('no', 'private', 'use_sidepath') THEN 'no'
+            WHEN bicycle IN ('no', 'dismount', 'private', 'use_sidepath') THEN 'no'
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway NOT IN ('motorway', 'motorway_link') AND tags->'vehicle' IN ('no', 'private') THEN 'no'
@@ -945,7 +945,7 @@ Layer:
             ELSE NULL
           END AS cycleway_right_oneway,
           CASE
-            WHEN bicycle IN ('no', 'private', 'use_sidepath') THEN 'no'
+            WHEN bicycle IN ('no', 'dismount', 'private', 'use_sidepath') THEN 'no'
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway IN ('motorway', 'motorway_link') THEN 'no'

--- a/roads.mss
+++ b/roads.mss
@@ -2884,15 +2884,14 @@
     //      line-color: lighten(@nomotor-fill, 10%);
     //    }
     //  }
-    /*  [can_bicycle='no'] {
-        line-color: @standard-nobicycle;
-        #tunnel { line-color: lighten(@standard-nobicycle, 5%); }
-      }*/
-  /*  [cyclestreet='yes'] { // a pedestrian street should not be a cyclestreet
+    /*  [cyclestreet='yes'] { // a pedestrian street should not be a cyclestreet
         line-color: @mixed-cycle-fill;
         #tunnel { line-color: lighten(@mixed-cycle-fill, 10%); }
     }*/
-    [can_bicycle='no'] {
+    // Default access for pedestrian is bicycle=dismount
+    // We need this order to ensure correct overloading of
+    // bicycle=yes|designated and speed inlines.
+    [can_bicycle=null], [can_bicycle='no'] {
       line-color: @standard-nobicycle;
       #tunnel { line-color: lighten(@standard-nobicycle, 5%); }
     }


### PR DESCRIPTION
`highway=pedestrian` with no extra tag are now greyed:

https://www.cyclosm.org/#map=18/48.87808/2.38647/cyclosm
![2020-08-08-165145](https://user-images.githubusercontent.com/3856586/89713373-a503cc00-d997-11ea-97c2-0fdf24a081ae.png)


`highway=pedestrian` + `bicycle=no|dismount` have the same rendering as no `bicycle` tag:

https://www.cyclosm.org/#map=18/48.87782/2.37984/cyclosm
![2020-08-08-165352](https://user-images.githubusercontent.com/3856586/89713391-bfd64080-d997-11ea-96d2-dfdb9315b5d2.png)


`highway=pedestrian` + `bicycle=yes|designated` have the previous rendering with color fill (and possible overloading with speed limits):

https://www.cyclosm.org/#map=19/48.86115/2.35059
![2020-08-08-165714](https://user-images.githubusercontent.com/3856586/89713495-3c691f00-d998-11ea-9775-0e557d747e48.png)


Closes #393.