### PR TITLE
turning_circle contour width

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -3472,7 +3472,11 @@
 #turning_circle_case[zoom>=14] {
   marker-fill: @standard-fill;
   marker-line-color: @standard-case;
-  marker-line-width: 2;
+  marker-line-width: 2*@rdz14_residential_outline;
+  [zoom>=15] { marker-line-width: 2*@rdz15_residential_outline; }
+  [zoom>=16] { marker-line-width: 2*@rdz16_residential_outline; }
+  [zoom>=17] { marker-line-width: 2*@rdz17_residential_outline; }
+  [zoom>=18] { marker-line-width: 2*@rdz18_residential_outline; }
   marker-allow-overlap: true;
 }
 #turning_circle_fill[zoom>=14] {


### PR DESCRIPTION
Hi ! Here is a new minor cosmetic fix

I've notices turning circles contour line is always 1px width, but roads casing width increases at high zoom.
I changes this to make circles and residential roads share the same contour width.

![turning_circle](https://user-images.githubusercontent.com/3080387/90308568-cfe2a880-dee0-11ea-8f48-984895f71f3d.png)

