### PR TITLE
Greener tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Render `public_transport=platform` + `shelter=yes` as shelter. See #378.
 * Render `surface=unpaved` as unknown surface + minor fixes for surfaces.
     See #367.
+* Render `highway=track` as dark green, instead of dark blue.
 
 
 ## v0.3.6

--- a/road-colors.mss
+++ b/road-colors.mss
@@ -48,7 +48,7 @@
 @speed20-fill: #bbffba;
 @speedWalk-fill: #ddffba;
 @nomotor-fill: #62ff96;
-@track-fill: #1b6634;
+@track-fill: #114021;
 @track-light1: lighten(@track-fill, 30%);
 @track-light2: lighten(@track-fill, 50);
 

--- a/road-colors.mss
+++ b/road-colors.mss
@@ -48,7 +48,7 @@
 @speed20-fill: #bbffba;
 @speedWalk-fill: #ddffba;
 @nomotor-fill: #62ff96;
-@track-fill: #1b3b66;
+@track-fill: #1b6634;
 @track-light1: lighten(@track-fill, 30%);
 @track-light2: lighten(@track-fill, 50);
 


### PR DESCRIPTION
Shift the hue of the tracks from 214° (very close to the hue of mixed-cycle-fill, which is 217°) to 140° (matching the hue of nomotor-fill), while maintaining the lightness and saturation. For reference, the hue of path-fill is 170° and cycle-fill is 240°, so with this change there is a continuum from roads that are (mostly) closed to motor vehicles (greenest) through paths that are either allowed or designated for bikes, but not reserved, to dedicated cycleways (bluest).

![base](https://user-images.githubusercontent.com/19811858/91657762-c4d46e80-eac3-11ea-9b7c-db62a0421416.png) vs 
![this change](https://user-images.githubusercontent.com/19811858/91657758-c43bd800-eac3-11ea-8211-2c74514a3a56.png).

The screenshots show a variety of backgrounds. I think the tracks are still quite visible even over forests, but it does stand out less there than the blue does. On other backgrounds (grass, farmland, plain) they are about the same.
