### PR TITLE
 Render lcn routes tagged on ways directly

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1126,7 +1126,7 @@ Layer:
           UNION ALL
           SELECT way, 'lcn' as type, tags->'lcn' AS state, 4 as priority
           FROM planet_osm_line
-          WHERE tags->'lcn' IS NOT NULL
+          WHERE tags->'lcn' IS NOT NULL AND tags->'lcn' NOT IN ('no', 'none')
         ) as routes_from_relations_and_ways
         ORDER BY priority DESC
       ) AS data

--- a/project.mml
+++ b/project.mml
@@ -1109,16 +1109,26 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT way, route, COALESCE(tags->'network', 'lcn') AS type, tags->'state' AS state
-        FROM planet_osm_line
-        WHERE route='bicycle'
-        ORDER BY CASE
-          WHEN tags->'network' = 'icn' THEN 0
-          WHEN tags->'network' = 'ncn' THEN 1
-          WHEN tags->'network' = 'rcn' THEN 2
-          WHEN tags->'network' = 'lcn' THEN 3
-          ELSE 4
-        END DESC
+        SELECT * FROM (
+          SELECT 
+            way,
+            COALESCE(tags->'network', 'lcn') AS type,
+            tags->'state' AS state,
+            CASE
+              WHEN tags->'network' = 'icn' THEN 0
+              WHEN tags->'network' = 'ncn' THEN 1
+              WHEN tags->'network' = 'rcn' THEN 2
+              WHEN tags->'network' = 'lcn' THEN 3
+              ELSE 4
+            END as priority
+          FROM planet_osm_line
+          WHERE route='bicycle'
+          UNION ALL
+          SELECT way, 'lcn' as type, NULL AS state, 4 as priority
+          FROM planet_osm_line
+          WHERE tags->'lcn' IS NOT NULL
+        ) as routes_from_relations_and_ways
+        ORDER BY priority DESC
       ) AS data
   geometry: linestring
   properties:

--- a/project.mml
+++ b/project.mml
@@ -1124,7 +1124,7 @@ Layer:
           FROM planet_osm_line
           WHERE route='bicycle'
           UNION ALL
-          SELECT way, 'lcn' as type, NULL AS state, 4 as priority
+          SELECT way, 'lcn' as type, tags->'lcn' AS state, 4 as priority
           FROM planet_osm_line
           WHERE tags->'lcn' IS NOT NULL
         ) as routes_from_relations_and_ways


### PR DESCRIPTION
LCN routes are often tagged with a simple `lcn=` tag on the ways, rather than with route relations, especially because they often aren't numbered/named. Other tiers of cycle routes are much-less-often tagged this way, see taginfo: [lcn](https://taginfo.openstreetmap.org/keys/lcn) [rcn](https://taginfo.openstreetmap.org/keys/rcn) [ncn](https://taginfo.openstreetmap.org/keys/ncn) [icn](https://taginfo.openstreetmap.org/keys/icn).

The most common value is `yes`, but the next most common is `proposed`, which should be rendered similarly to relation-based routes with `state=proposed`, presumably.