### PR TITLE
Place cycleways and paths at top of z-order hierarchy

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -578,8 +578,8 @@ Layer:
             ELSE 'unknown'
           END AS surface_type,
           CASE
-            WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer - 61 ELSE -61 END
-            WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer - 62 ELSE -62 END
+            WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer - 1 ELSE -1 END
+            WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer - 2 ELSE -2 END
             ELSE z_order
           END AS z_order
         FROM planet_osm_line
@@ -763,8 +763,8 @@ Layer:
             ELSE NULL
           END AS mtb_scale_imba,
           CASE
-            WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+39 ELSE 39 END
-            WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+38 ELSE 38 END
+            WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+99 ELSE 99 END
+            WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+98 ELSE 98 END
             ELSE z_order
           END AS z_order
         FROM planet_osm_line
@@ -1018,8 +1018,8 @@ Layer:
             ELSE 'unknown'
           END AS surface_type,
           CASE
-            WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+139 ELSE 139 END
-            WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+138 ELSE 138 END
+            WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+199 ELSE 199 END
+            WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+198 ELSE 198 END
             ELSE z_order
           END AS z_order
         FROM planet_osm_line


### PR DESCRIPTION
Promote cycleways / paths with bikes allowed to z_order 99 and other paths to 98. This ensures they always render on-top of roads at the same layer, even when those roads are also tagged with railway= and so get a +35 boost to their z_order (see https://github.com/openstreetmap/osm2pgsql/blob/a424919b7810922be5586d6e24cf25126b4557ad/src/tagtransform-c.cpp#L61 for this behaviour). 

Note that tram tracks are still drawn on-top of cycleways/paths, as are railroad tracks, even after this change. This fixes #431 .

![z17](https://user-images.githubusercontent.com/19811858/92808182-ceab7b00-f3bb-11ea-907a-013f2dcaa1f6.png)
![z14](https://user-images.githubusercontent.com/19811858/92808305-ee42a380-f3bb-11ea-924a-550762b80023.png)

