### PR TITLE
Houseboats and ferry routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Render `leisure=track`. See #412.
 * Render footway areas with a brownish tone. See #370.
 * Render linear `highway=ford`. See #424.
+* Making ferry routes that can carry bikes more blue.
 
 
 ## v0.3.6

--- a/base.mss
+++ b/base.mss
@@ -2,7 +2,8 @@
  * - Landuse & landcover
  * - Water areas
  * - Water ways
- * - Administrative Boundaries
+ * - Barriers
+ * - Buildings
  *
  */
 
@@ -250,16 +251,6 @@
   opacity: 0.4; // The entire layer has opacity to handle overlapping forests
 }
 
-/* ---- BUILDINGS ---- */
-#buildings[zoom>=16] {
-  polygon-fill: @building;
-
-  /* Render perimeter of buildings in high zooms */
-  [zoom>=18] {
-    line-color: #b6b2af;
-    line-width: 0.75;
-  }
-}
 
 /* ================================================================== */
 /* WATER AREAS
@@ -501,5 +492,16 @@ Map { background-color: @water; }
     [zoom >= 20] {
       line-width: 5;
     }
+  }
+}
+
+/* ---- BUILDINGS ---- */
+#buildings[zoom>=16] {
+  polygon-fill: @building;
+
+  /* Render perimeter of buildings in high zooms */
+  [zoom>=18] {
+    line-color: #b6b2af;
+    line-width: 0.75;
   }
 }

--- a/ferry-routes.mss
+++ b/ferry-routes.mss
@@ -12,6 +12,9 @@
       line-width: 0.8;
       line-dasharray: 6,6;
     }
+    [bicycle!=null][bicycle!='no'] {
+      line-color: @cycle-fill;
+    }
   }
 }
 

--- a/project.mml
+++ b/project.mml
@@ -40,12 +40,12 @@ Stylesheet:
 - fonts.mss
 - base.mss
 - aerialways.mss
+- ferry-routes.mss
 - roads.mss
 - amenities.mss
 - labels.mss
 - placenames.mss
 - addressing.mss
-- ferry-routes.mss
 - power.mss
 - admin.mss
 - gpx.mss
@@ -1082,6 +1082,21 @@ Layer:
       ) AS admin_high_zoom
   properties:
     minzoom: 13
+- id: ferry-routes
+  geometry: linestring
+  <<: *extents
+  Datasource:
+    <<: *osm2pgsql
+    table: |-
+      (SELECT
+          way,
+          bicycle
+        FROM planet_osm_line
+        WHERE route = 'ferry'
+          AND osm_id > 0
+      ) AS ferry_routes
+  properties:
+    minzoom: 8
 - id: bicycle_routes_gen0
   <<: *extents
   Datasource:
@@ -1181,20 +1196,6 @@ Layer:
   geometry: linestring
   properties:
     minzoom: 11
-- id: ferry-routes
-  geometry: linestring
-  <<: *extents
-  Datasource:
-    <<: *osm2pgsql
-    table: |-
-      (SELECT
-          way
-        FROM planet_osm_line
-        WHERE route = 'ferry'
-          AND osm_id > 0
-      ) AS ferry_routes
-  properties:
-    minzoom: 8
 - id: route
   <<: *extents84
   Datasource:

--- a/project.mml
+++ b/project.mml
@@ -192,25 +192,6 @@ Layer:
   geometry: raster
   properties:
     status: off
-- id: buildings
-  <<: *extents
-  Datasource:
-    <<: *osm2pgsql
-    table: |-
-      (
-        SELECT
-          way,
-          building AS type
-        FROM planet_osm_polygon
-        WHERE building IS NOT NULL
-          AND building != 'no'
-          AND way_area > 1*!pixel_width!::real*!pixel_height!::real
-          AND (tags->'location' IS NULL OR tags->'location' != 'underground')
-        ORDER BY z_order ASC, way_area DESC
-      ) AS data
-  geometry: polygon
-  properties:
-    minzoom: 16
 #- id: contours100
 #  class: contours
 #  <<: *extents
@@ -402,6 +383,25 @@ Layer:
   geometry: polygon
   properties:
     minzoom: 13
+- id: buildings
+  <<: *extents
+  Datasource:
+    <<: *osm2pgsql
+    table: |-
+      (
+        SELECT
+          way,
+          building AS type
+        FROM planet_osm_polygon
+        WHERE building IS NOT NULL
+          AND building != 'no'
+          AND way_area > 1*!pixel_width!::real*!pixel_height!::real
+          AND (tags->'location' IS NULL OR tags->'location' != 'underground')
+        ORDER BY z_order ASC, way_area DESC
+      ) AS data
+  geometry: polygon
+  properties:
+    minzoom: 16
 - id: piers-poly
   geometry: polygon
   <<: *extents


### PR DESCRIPTION
Hello here!

Here is a new pull request containing:
* Buildings layer rendered above water,  because today `building=houseboat` are hidden uder water
* Ferry routes layer rendered below cycling routes : Needed because ferry routes rendering contains a ˋ@waterˋ blue background trick. 
* Ferry routes now more blue (in ˋ@cycle-fill`) when they accept bicycles. 

![10388C79-E999-4E9D-8F25-D8CDE6862D33](https://user-images.githubusercontent.com/3080387/93706408-38e3be80-fb26-11ea-8b07-32b515771c38.png)
![4B7204F1-DAA5-48B7-8D22-1A1110FAE346](https://user-images.githubusercontent.com/3080387/93706410-3b461880-fb26-11ea-921e-99f91d1d2d4f.png)
