### PR TITLE
fix proposed route no more rendered with dashes

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -1180,6 +1180,7 @@ Layer:
           SELECT way, 'lcn' as type, tags->'lcn' AS state, 4 as priority
           FROM planet_osm_line
           WHERE tags->'lcn' IS NOT NULL AND tags->'lcn' NOT IN ('no', 'none')
+            AND highway IS NOT NULL
         ) as routes_from_relations_and_ways
         ORDER BY priority DESC
       ) AS data


### PR DESCRIPTION
Hello,
Great to see last updates released, thank you!

But I have noticed a new issue : routes with `state='proposed'` are no more dotted.
Here is a fix

![Screen Shot 2020-10-07 at 00 09 25](https://user-images.githubusercontent.com/3080387/95265415-71c3a900-0831-11eb-8066-514d1725ea18.png)
