### PR TITLE
Better segregated rendering

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -544,7 +544,8 @@ Layer:
             ELSE NULL
           END AS can_bicycle,
           CASE
-            WHEN tags->'segregated' IN ('yes') THEN 'yes'
+            WHEN tags->'segregated' = 'yes' AND (horse IN ('designated', 'yes') OR highway='bridleway' OR (highway='path' AND horse != 'no')) THEN 'horse'
+            WHEN tags->'segregated' = 'yes' THEN 'foot'
             ELSE 'no'
           END AS segregated,
           CASE
@@ -721,7 +722,8 @@ Layer:
             ELSE NULL
           END AS can_bicycle,
           CASE
-            WHEN tags->'segregated' IN ('yes') THEN 'yes'
+            WHEN tags->'segregated' = 'yes' AND (horse IN ('designated', 'yes') OR highway='bridleway' OR (highway='path' AND horse != 'no')) THEN 'horse'
+            WHEN tags->'segregated' = 'yes' THEN 'foot'
             ELSE 'no'
           END AS segregated,
           CASE
@@ -984,7 +986,8 @@ Layer:
             ELSE NULL
           END AS can_bicycle,
           CASE
-            WHEN tags->'segregated' IN ('yes') THEN 'yes'
+            WHEN tags->'segregated' = 'yes' AND (horse IN ('designated', 'yes') OR highway='bridleway' OR (highway='path' AND horse != 'no')) THEN 'horse'
+            WHEN tags->'segregated' = 'yes' THEN 'foot'
             ELSE 'no'
           END AS segregated,
           CASE

--- a/roads.mss
+++ b/roads.mss
@@ -756,23 +756,29 @@
 }
 
 
-#roads_high::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated!='no'],
-#tunnel::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated!='no'],
-#bridge::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated!='no'] {
+#roads_high::path_outline_right[zoom>=17][type='path'][can_bicycle!='no'][segregated!='no'],
+#tunnel::path_outline_right[zoom>=17][type='path'][can_bicycle!='no'][segregated!='no'],
+#bridge::path_outline_right[zoom>=17][type='path'][can_bicycle!='no'][segregated!='no'] {
   line-cap: butt;
   [segregated='foot'] { line-color: @footway-fill; }
   [segregated='horse'] { line-color: @bridleway-fill; }
 
   line-width: @rdz17_path;
-  line-offset: @rdz17_path/2 + @rdz17_cycle/2;
-  [oneway='no'][oneway_bicycle='no'] {
-    line-width: @rdz17_path; line-offset: @rdz17_path/2 + @rdz17_cycle*1.5/2;
+  line-offset: @rdz17_path;
+  [can_bicycle='designated'] {
+    line-offset: @rdz17_path/2 + @rdz17_cycle/2;
+    [oneway='no'][oneway_bicycle='no'] {
+      line-width: @rdz17_path; line-offset: @rdz17_path/2 + @rdz17_cycle*1.5/2;
+    }
   }
   [zoom>=18] {
     line-width: @rdz18_path;
-    line-offset: @rdz18_path/2 + @rdz18_cycle/2;
-    [oneway='no'][oneway_bicycle='no']{
-      line-width: @rdz18_path; line-offset: @rdz18_path/2 + @rdz18_cycle*1.5/2;
+    line-offset: @rdz18_path;
+    [can_bicycle='designated'] {
+      line-offset: @rdz18_path/2 + @rdz18_cycle/2;
+      [oneway='no'][oneway_bicycle='no']{
+        line-width: @rdz18_path; line-offset: @rdz18_path/2 + @rdz18_cycle*1.5/2;
+      }
     }
   }
 }

--- a/roads.mss
+++ b/roads.mss
@@ -756,11 +756,12 @@
 }
 
 
-#roads_high::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated='yes'],
-#tunnel::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated='yes'],
-#bridge::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated='yes'] {
+#roads_high::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated!='no'],
+#tunnel::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated!='no'],
+#bridge::path_outline_right[zoom>=17][type='path'][can_bicycle='designated'][segregated!='no'] {
   line-cap: butt;
-  line-color: @path-fill;
+  [segregated='foot'] { line-color: @footway-fill; }
+  [segregated='horse'] { line-color: @bridleway-fill; }
 
   line-width: @rdz17_path;
   line-offset: @rdz17_path/2 + @rdz17_cycle/2;
@@ -3301,7 +3302,7 @@
       line-color: @mixed-cycle-fill;
       #tunnel { line-color: lighten(@mixed-cycle-fill, 10%); }
 
-      [segregated='yes'] {
+      [segregated!='no'] {
         line-color: @cycle-fill;
         #tunnel { line-color: lighten(@cycle-fill, 15%); }
       }


### PR DESCRIPTION
This PR does two things:

First, it changes the colour of the pedestrian side-way, rendered at z17+ when `segregated=yes`, away from green. Green would have made sense before footways were shifted from green to brown, but now it doesn't so much - if two separate lines are rendered, the non-bicycle one should be rendered as non-bicycle ways are normally: brown. The colour of a bridleway is used if the way supports horse-riders, otherwise the colour of a footway:

TODO pic with foot
TODO pic with horse

Secondly, and dependent of the first change, it adds support for rendering the side-way for segregated paths that don't have `bicycle=designated` (designated is only tagged in some countries when a path legally requires usage; in these countries it doesn't imply anything about the quality of the path for cyclists, and a `bicycle=yes segregated=yes` path could be equal or higher-standard). This would have been confusing before the colour change, because it would have just rendered a path-coloured side-way next to the path-coloured main way, which would have just looked like a fat path, not two side-by-side ways. Now with the brown colour it works:

TODO pic with path