### PR TITLE
Fix bug in motorway_link colour

### DIFF
--- a/roads.mss
+++ b/roads.mss
@@ -2181,7 +2181,7 @@
     line-join: round;
     line-color: @motorway-trunk-cycle-fill;
     #tunnel { line-color: lighten(@motorway-trunk-cycle-fill, 10%); }
-    [can_bicycle='yes'] {
+    [can_bicycle='no'] {
       line-color: @motorway-trunk-fill;
       #tunnel { line-color: lighten(@motorway-trunk-fill, 10%); }
     }


### PR DESCRIPTION
The condition for the motorway_link (and trunk_link) fill colour was the wrong way around, so that it was shown as cycleable unless bicycle=yes.

Fixes #452.