### PR TITLE
Fix drinking water, toilets, acess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Make roads more visible at Z11. See #447.
 * Render `admin_level=4` (states / regions) with dash from z4 to avoid miximg
     them up with railways. See #447.
+* Rework drinking water icon
+* Distinguish toilets with drinking water.
+* Distinguish access for toilets and drinking water.
 
 
 ## v0.3.7

--- a/amenities.mss
+++ b/amenities.mss
@@ -665,12 +665,20 @@
   [feature = 'amenity_drinking_water'][zoom >= 16],
   [feature = 'amenity_water_point']['drinking_water'='yes'][zoom >= 16],
   [feature = 'man_made_water_tap']['drinking_water'='yes'][zoom >= 16] {
-    marker-file: url('symbols/osm-bright-gl-style/amenities/drinking_water_11.svg');
+    marker-file: url('symbols/openstreetmap-carto/amenity/drinking_water_full.svg');
     marker-fill: @amenity-water;
+    [access != ''][access != 'permissive'][access != 'yes'] {
+      marker-opacity: 0.33;
+    }
   }
   [feature = 'amenity_toilets'][zoom >= 16] {
     marker-file: url('symbols/osm-bright-gl-style/amenities/toilets_11.svg');
-    marker-fill: @amenity-water;
+    marker-fill: @health-color;
+    [drinking_water = 'yes'] { marker-fill: @amenity-water; }
+
+    [access != ''][access != 'permissive'][access != 'yes'] {
+      marker-opacity: 0.33;
+    }
   }
 
   [feature = 'shop_supermarket'][zoom >= 16] {

--- a/palette.mss
+++ b/palette.mss
@@ -173,7 +173,7 @@
 @gastronomy-text: darken(@gastronomy-icon, 5%);
 @shop-icon: #666;
 @shop-text: darken(@shop-icon, 5%);
-@amenity-water: #007ae2;
+@amenity-water: #3b029a;
 @amenity-common: #666;
 @memorials: @amenity-common;
 @man-made-icon: #666;

--- a/symbols/openstreetmap-carto/amenity/drinking_water.svg
+++ b/symbols/openstreetmap-carto/amenity/drinking_water.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="14"
+   height="14"
+   viewBox="0 0 14 14">
+  <rect
+     width="14"
+     height="14"
+     x="0"
+     y="0"
+     id="canvas"
+     style="fill:none;stroke:none;visibility:hidden" />
+  <path
+     d="m 1,6 1.5,8 5,0 L 9,6 z M 2.18,7 7.81,7 7.44,9 2.55,9 M 4,5 C 4,3 5,2 7,2 L 8,2 8,1 7,1 C 6,1 6,0 7,0 l 3,0 c 1,0 1,1 0,1 l -1,0 0,1 4,0 0,1.5 -6,0 C 5.91526,3.49111 5.5,3.9824765 5.5,5 z"
+     id="drinking-water" />
+</svg>

--- a/symbols/openstreetmap-carto/amenity/drinking_water_full.svg
+++ b/symbols/openstreetmap-carto/amenity/drinking_water_full.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" width="14" height="14" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
+  <rect width="14" height="14" x="0" y="0" id="canvas" style="fill:none;stroke:none;visibility:hidden"/>
+  <path d="M 1 6 L 2.5 14 L 7.5 14 L 9 6 L 1 6 Z M 4 5 C 4 3 5 2 7 2 L 8 2 L 8 1 L 7 1 C 6 1 6 0 7 0 L 10 0 C 11 0 11 1 10 1 L 9 1 L 9 2 L 13 2 L 13 3.5 L 7 3.5 C 5.915 3.491 5.5 3.982 5.5 5 L 4 5 Z" id="drinking-water"/>
+</svg>


### PR DESCRIPTION
* Rework drinking water icon
* Distinguish toilets with drinking water.
* Distinguish access for toilets and drinking water.

Fix #399 #454

![Screenshot_20201116_142501](https://user-images.githubusercontent.com/47089717/99259673-a35d6600-281a-11eb-8664-522aeb86853f.png)
![Screenshot_20201116_142414](https://user-images.githubusercontent.com/47089717/99259678-a3f5fc80-281a-11eb-8281-8b845d205c01.png)
![Screenshot_20201116_142325](https://user-images.githubusercontent.com/47089717/99259682-a48e9300-281a-11eb-9ae4-105c8daa5dfb.png)
 