### PR TITLE
Truncate long cycle junction names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Distinguish access for toilets and drinking water.
 * Add subicon at POI for bicycle services (pump, tool, rental/repair/retail).
 * Render islands names. See #456.
+* Truncate cycle junction names. See #381.
 
 
 ## v0.3.7

--- a/project.mml
+++ b/project.mml
@@ -1331,7 +1331,11 @@ Layer:
       (
         SELECT
           way,
-          COALESCE(tags->'icn_ref', tags->'ncn_ref', tags->'rcn_ref', tags->'lcn_ref') AS ref,
+          CONCAT(SUBSTR(
+            COALESCE(tags->'icn_ref', tags->'ncn_ref', tags->'rcn_ref', tags->'lcn_ref'),
+            0,
+            4
+          ), '.') AS ref,
           CASE
             WHEN (tags->'icn_ref') IS NOT NULL THEN 'icn'
             WHEN (tags->'ncn_ref') IS NOT NULL THEN 'ncn'


### PR DESCRIPTION
Fix #381 

See https://www.cyclosm.org/#map=19/48.46640/-4.56664/cyclosm

Render is 
![2020-11-25-230737](https://user-images.githubusercontent.com/3856586/100286405-11b8cb80-2f73-11eb-8ae9-9c65983a1090.png)

If we want to keep the actual render (which is good, in my opinion), we only have two options:
* Either we respawn our shield building script to generate the background shield in a variety of sizes and formats. Looking at the lcn_ref values from taginfo, I'm definitely not convinced this would be clean enough as the shield names can be arbitrarily long.
* Or we truncate the cycle junction name. My bet here is that non-numeric cycle junction names are likely places names. Hence, given the surroundings in the map, having just a few letters can disambiguate and make a nice render.
