### PR TITLE
Add cycle route name label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     activation through localconfig.**
 * Render `sidewalk:{left,right,both}:bicycle` as shared cycle tracks.
     See #464.
+* Add cycle route name.
 
 
 ## v0.3.7

--- a/labels.mss
+++ b/labels.mss
@@ -591,9 +591,8 @@
   shield-clip: @shield-clip;
   shield-file: url("symbols/shields/[type]_[width]x[height].svg");
   shield-transform: "scale(0.75)";
-  [route='bicycle'][type='icn'] {
-    shield-fill: @icn-shield-fill;
-  }
+
+  shield-fill: @icn-shield-fill;
   [route='bicycle'][type='ncn'] {
     shield-fill: @ncn-shield-fill;
   }
@@ -606,6 +605,36 @@
   [route='mtb'] {
     shield-fill: @mtb-shield-fill;
     shield-file: url("symbols/shields/mtb_[width]x[height].svg");
+  }
+
+  //Route name label
+  [zoom >= 16]
+  {
+    text-size: 9;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @road_halo;
+    text-spacing: 900;
+    text-clip: false;
+    text-placement: line;
+    text-face-name: @sans;
+    text-vertical-alignment: top;
+    text-dy: 12;
+    text-repeat-distance: 900;
+    text-name: "[name]";
+
+    text-fill: darken(@icn-overlay, 25%);
+    [route='bicycle'][type='ncn'] {
+      text-fill: darken(@ncn-overlay, 25%);
+    }
+    [route='bicycle'][type='rcn'] {
+      text-fill: darken(@rcn-overlay, 25%);
+    }
+    [route='bicycle'][type='lcn'] {
+      text-fill: darken(@lcn-overlay, 25%);
+    }
+    [route='mtb'] {
+      text-fill: darken(@mtb-overlay, 25%);
+    }
   }
 }
 

--- a/palette.mss
+++ b/palette.mss
@@ -104,7 +104,6 @@
 @ferry-route-text: @ferry-route;
 
 @conditional-text: #ff2701;
-@conditional-cycle-text: #0000ce;
 
 /* Also used for other small places: hamlets, suburbs, localities */
 @village_text:      #444;
@@ -121,8 +120,8 @@
 
 @shield-size: 10;
 @shield-line-spacing: -1.5;
-@shield-spacing: 760;
-@shield-repeat-distance: 400;
+@shield-spacing: 900;
+@shield-repeat-distance: 700;
 @shield-margin: 40;
 @shield-face-name: @sans;
 @shield-clip: false;

--- a/project.mml
+++ b/project.mml
@@ -1629,7 +1629,7 @@ Layer:
     <<: *osm2pgsql
     table: |-
       (
-        SELECT way, route, tags->'network' AS type, ref, 1 as height, char_length(ref) AS width
+        SELECT way, route, tags->'network' AS type, ref, name, 1 as height, char_length(ref) AS width
         FROM planet_osm_line
         WHERE (route = 'bicycle' OR route = 'mtb')
           AND ref IS NOT NULL


### PR DESCRIPTION
Render next to the road the name of the cycle route with the network color darkened.
From z16.
Shield are more spaced to compensate the density.

fix #433

![Screenshot_20201202_163207](https://user-images.githubusercontent.com/47089717/100898919-8c2ca280-34c1-11eb-9814-752139bb8a55.png)
