### PR TITLE
Render minor service roads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Render `sidewalk:{left,right,both}:bicycle` as shared cycle tracks.
     See #464.
 * Add cycle route name.
+* Render parking amenity and servie road parking aisle, drive-through, driveway smaller.
 
 
 ## v0.3.7

--- a/amenities.mss
+++ b/amenities.mss
@@ -1164,19 +1164,16 @@
     marker-clip: false;
   }
   [feature='amenity_parking'] {
-    #amenities-poly[zoom >= 14][area > 25000],
-    #amenities-poly[zoom >= 17][area > 250],
+    #amenities-poly[zoom >= 16][area > 25000],
+    #amenities-poly[zoom >= 18][area > 250],
     [zoom >= 19] {
       marker-file: url('symbols/openstreetmap-carto/amenity/parking.svg');
       marker-clip: false;
       marker-fill: @amenity-common;
       marker-placement: interior;
+      marker-width: 10;
 
       [access != ''][access != 'permissive'][access != 'yes'] { marker-opacity: 0.33; }
-
-      [zoom = 16] { marker-width: 10; }
-      [zoom = 15] { marker-width: 8; }
-      [zoom = 14] { marker-width: 6; }
     }
   }
 }

--- a/amenities.mss
+++ b/amenities.mss
@@ -1163,6 +1163,22 @@
     marker-fill: @amenity-common;
     marker-clip: false;
   }
+  [feature='amenity_parking'] {
+    #amenities-poly[zoom >= 14][area > 25000],
+    #amenities-poly[zoom >= 17][area > 250],
+    [zoom >= 19] {
+      marker-file: url('symbols/openstreetmap-carto/amenity/parking.svg');
+      marker-clip: false;
+      marker-fill: @amenity-common;
+      marker-placement: interior;
+
+      [access != ''][access != 'permissive'][access != 'yes'] { marker-opacity: 0.33; }
+
+      [zoom = 16] { marker-width: 10; }
+      [zoom = 15] { marker-width: 8; }
+      [zoom = 14] { marker-width: 6; }
+    }
+  }
 }
 
 #amenities-points,

--- a/project.mml
+++ b/project.mml
@@ -83,7 +83,7 @@ Layer:
             CASE WHEN landuse IS NOT NULL THEN ('landuse_' || landuse) ELSE NULL END,
             CASE WHEN "natural" IS NOT NULL THEN ('natural_' || "natural") ELSE NULL END,
             CASE WHEN leisure IS NOT NULL THEN ('leisure_' || leisure) ELSE NULL END,
-            CASE WHEN amenity IS NOT NULL THEN ('amenity' || amenity) ELSE NULL END,
+            CASE WHEN amenity IS NOT NULL THEN ('amenity_' || amenity) ELSE NULL END,
             CASE WHEN highway IN ('pedestrian') THEN ('highway_' || highway) ELSE NULL END
           ) AS type
           FROM planet_osm_polygon
@@ -586,6 +586,10 @@ Layer:
             ELSE 'unknown'
           END AS surface_type,
           CASE
+            WHEN service in ('parking_aisle', 'drive-through', 'driveway') THEN 'minor'
+            ELSE service
+          END AS service,
+          CASE
             WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer - 1 ELSE -1 END
             WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer - 2 ELSE -2 END
             ELSE z_order
@@ -770,6 +774,10 @@ Layer:
               THEN 'road'
             ELSE 'unknown'
           END AS surface_type,
+          CASE
+            WHEN service in ('parking_aisle', 'drive-through', 'driveway') THEN 'minor'
+            ELSE service
+          END AS service,
           CASE
             WHEN tags->'mtb:scale'~E'^\\d+[+-]?$' THEN REPLACE(REPLACE(tags->'mtb:scale', '+', ''), '-', '')::integer
             ELSE NULL
@@ -1041,6 +1049,10 @@ Layer:
               THEN 'road'
             ELSE 'unknown'
           END AS surface_type,
+          CASE
+            WHEN service in ('parking_aisle', 'drive-through', 'driveway') THEN 'minor'
+            ELSE service
+          END AS service,
           CASE
             WHEN highway='cycleway' OR (highway IN ('path', 'footway', 'pedestrian', 'bridleway') AND bicycle IN ('yes', 'designated')) THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+199 ELSE 199 END
             WHEN highway IN ('path', 'footway', 'pedestrian', 'bridleway') THEN CASE WHEN layer~E'^\\d+$' THEN 100*layer::integer+198 ELSE 198 END
@@ -1725,12 +1737,13 @@ Layer:
           covered,
           tags->'shelter' AS shelter,
           way,
+          way_area AS area,
           name,
           COALESCE( -- order is important here
             'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,
             'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel', 'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery') THEN tourism ELSE NULL END,
             'shop_' ||  CASE WHEN shop IN ('bicycle', 'bakery', 'beverage', 'convenience', 'convenience;gas', 'gas', 'greengrocer', 'supermarket', 'pastry', 'sports') THEN shop ELSE NULL END,
-            'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'clinic', 'doctors', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'fuel', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
+            'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'clinic', 'doctors', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'fuel', 'hospital', 'ice_cream', 'internet_cafe', 'parking', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
             'shop_' || CASE WHEN tags->'service:bicycle:retail'='yes' OR tags->'service:bicycle:repair'='yes' OR tags->'service:bicycle:rental'='yes' THEN 'bicycle' ELSE NULL END,
             'emergency_' || CASE WHEN tags->'emergency' IS NOT NULL THEN tags->'emergency' ELSE NULL END,
             'healthcare_' || CASE WHEN tags->'healthcare' IN ('clinic', 'hospital') THEN tags->'healthcare' ELSE NULL END,
@@ -1797,7 +1810,7 @@ Layer:
           OR amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
                          'biergarten', 'cafe', 'car_wash', 'compressed_air', 'clinic', 'doctors', 'drinking_water', 'fast_food',
                          'ferry_terminal', 'food_court', 'fountain', 'fuel', 'hospital', 'ice_cream', 'internet_cafe',
-                         'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath',
+                         'parking', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath',
                          'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre',
                          'bureau_de_change', 'casino', 'library')
           OR tags->'car_wash'='yes'
@@ -1869,7 +1882,7 @@ Layer:
             'aeroway_' || CASE WHEN aeroway IN ('helipad', 'aerodrome') THEN aeroway ELSE NULL END,
             'tourism_' || CASE WHEN tourism IN ('artwork', 'alpine_hut', 'camp_site', 'caravan_site', 'chalet', 'wilderness_hut', 'guest_house', 'apartment', 'hostel', 'hotel', 'motel', 'information', 'museum', 'viewpoint', 'picnic_site', 'gallery') THEN tourism ELSE NULL END,
             'shop_' ||  CASE WHEN shop IN ('bicycle', 'bakery', 'beverage', 'convenience', 'convenience;gas', 'gas', 'greengrocer', 'supermarket', 'pastry', 'sports') THEN shop ELSE NULL END,
-            'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'clinic', 'doctors', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'fuel', 'hospital', 'ice_cream', 'internet_cafe', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
+            'amenity_' || CASE WHEN amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station', 'biergarten', 'cafe', 'car_wash', 'compressed_air', 'clinic', 'doctors', 'drinking_water', 'fast_food', 'ferry_terminal', 'food_court', 'fountain', 'fuel', 'hospital', 'ice_cream', 'internet_cafe', 'parking', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath', 'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre', 'bureau_de_change', 'casino', 'library', 'motorcycle_parking', 'charging_station', 'vending_machine') THEN amenity ELSE NULL END,
             'shop_' || CASE WHEN tags->'service:bicycle:retail'='yes' OR tags->'service:bicycle:repair'='yes' OR tags->'service:bicycle:rental'='yes' THEN 'bicycle' ELSE NULL END,
             'emergency_' || CASE WHEN tags->'emergency' IS NOT NULL THEN tags->'emergency' ELSE NULL END,
             'healthcare_' || CASE WHEN tags->'healthcare' IN ('clinic', 'hospital') THEN tags->'healthcare' ELSE NULL END,
@@ -1952,7 +1965,7 @@ Layer:
           OR amenity IN ('atm', 'bank', 'bar', 'bench', 'bicycle_rental', 'bicycle_parking', 'bicycle_repair_station',
                          'biergarten', 'cafe', 'car_wash', 'compressed_air', 'clinic', 'doctors', 'drinking_water', 'fast_food',
                          'ferry_terminal', 'food_court', 'fountain', 'fuel', 'hospital', 'ice_cream', 'internet_cafe',
-                         'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath',
+                         'parking', 'pharmacy', 'place_of_worship', 'police', 'post_office', 'post_box', 'pub', 'public_bath',
                          'restaurant', 'shelter', 'shower', 'toilets', 'water_point', 'cinema', 'theatre',
                          'bureau_de_change', 'casino', 'library')
           OR tags->'car_wash'='yes'

--- a/roads.mss
+++ b/roads.mss
@@ -720,6 +720,14 @@
     [zoom>=16] { line-width: @rdz16_service + (2 * @rdz16_service_outline); }
     [zoom>=17] { line-width: @rdz17_service + (2 * @rdz17_service_outline); }
     [zoom>=18] { line-width: @rdz18_service + (2 * @rdz18_service_outline); }
+
+    [zoom>=12][service='minor'] { line-width: 0; }
+    [zoom>=13][service='minor'] { line-width: 0; }
+    [zoom>=14][service='minor'] { line-width: 0; }
+    [zoom>=15][service='minor'] { line-width: 0; }
+    [zoom>=16][service='minor'] { line-width: @rdz16_service*0.5 + @rdz16_service_outline*0.7; }
+    [zoom>=17][service='minor'] { line-width: @rdz17_service*0.8 + @rdz17_service_outline; }
+    [zoom>=18][service='minor'] { line-width: @rdz18_service*0.8 + @rdz18_service_outline; }
   }
 
   #bridge::outline {
@@ -2844,6 +2852,14 @@
     [zoom>=16] { line-width: @rdz16_service; }
     [zoom>=17] { line-width: @rdz17_service; }
     [zoom>=18] { line-width: @rdz18_service; }
+
+    [zoom>=12][service='minor'] { line-width: 0; }
+    [zoom>=13][service='minor'] { line-width: 0; }
+    [zoom>=14][service='minor'] { line-width: 0; }
+    [zoom>=15][service='minor'] { line-width: 0; }
+    [zoom>=16][service='minor'] { line-width: @rdz16_service*0.5; }
+    [zoom>=17][service='minor'] { line-width: @rdz17_service*0.8; }
+    [zoom>=18][service='minor'] { line-width: @rdz18_service*0.8; }
 
     line-color: @standard-fill;
     #tunnel { line-color: lighten(@standard-fill, 10%); }

--- a/roads.mss
+++ b/roads.mss
@@ -700,7 +700,7 @@
     [zoom>=17] { line-width: @rdz17_pedestrian + (2 * @rdz17_pedestrian_outline); }
     [zoom>=18] { line-width: @rdz18_pedestrian + (2 * @rdz18_pedestrian_outline); }
   }
-  [type='service'] {
+  [type='service'][service!='minor'] {
     line-cap: round;
     line-join: round;
     #tunnel::outline,
@@ -720,14 +720,24 @@
     [zoom>=16] { line-width: @rdz16_service + (2 * @rdz16_service_outline); }
     [zoom>=17] { line-width: @rdz17_service + (2 * @rdz17_service_outline); }
     [zoom>=18] { line-width: @rdz18_service + (2 * @rdz18_service_outline); }
+  }
+  [type='service'][service='minor'][zoom>=15] {
+    line-cap: round;
+    line-join: round;
+    #tunnel::outline,
+    #bridge::outline {
+      line-cap: butt;
+    }
+    #tunnel::outline {
+      line-dasharray: 3,3;
+    }
 
-    [zoom>=12][service='minor'] { line-width: 0; }
-    [zoom>=13][service='minor'] { line-width: 0; }
-    [zoom>=14][service='minor'] { line-width: 0; }
-    [zoom>=15][service='minor'] { line-width: 0; }
-    [zoom>=16][service='minor'] { line-width: @rdz16_service*0.5 + @rdz16_service_outline*0.7; }
-    [zoom>=17][service='minor'] { line-width: @rdz17_service*0.8 + @rdz17_service_outline; }
-    [zoom>=18][service='minor'] { line-width: @rdz18_service*0.8 + @rdz18_service_outline; }
+    line-color: @standard-case;
+
+    line-width: @rdz15_service*0.5 + @rdz15_service_outline;
+    [zoom>=16] { line-width: @rdz16_service*0.5 + @rdz16_service_outline; }
+    [zoom>=17] { line-width: @rdz17_service*0.5 + @rdz17_service_outline; }
+    [zoom>=18] { line-width: @rdz18_service*0.5 + @rdz18_service_outline; }
   }
 
   #bridge::outline {
@@ -2842,7 +2852,7 @@
     }
   }
 
-  [type='service'][zoom>=12] {
+  [type='service'][service!='minor'][zoom>=12] {
     line-cap: round;
     line-join: round;
     line-width: @rdz12_service;
@@ -2852,14 +2862,6 @@
     [zoom>=16] { line-width: @rdz16_service; }
     [zoom>=17] { line-width: @rdz17_service; }
     [zoom>=18] { line-width: @rdz18_service; }
-
-    [zoom>=12][service='minor'] { line-width: 0; }
-    [zoom>=13][service='minor'] { line-width: 0; }
-    [zoom>=14][service='minor'] { line-width: 0; }
-    [zoom>=15][service='minor'] { line-width: 0; }
-    [zoom>=16][service='minor'] { line-width: @rdz16_service*0.5; }
-    [zoom>=17][service='minor'] { line-width: @rdz17_service*0.8; }
-    [zoom>=18][service='minor'] { line-width: @rdz18_service*0.8; }
 
     line-color: @standard-fill;
     #tunnel { line-color: lighten(@standard-fill, 10%); }
@@ -2918,6 +2920,71 @@
         }
       }
     }
+  }
+  [type='service'][service='minor'][zoom>=15] {
+    line-cap: round;
+    line-join: round;
+    line-width: @rdz15_service*0.5;
+    [service='minor'][zoom>=16] { line-width: @rdz16_service*0.5; }
+    [service='minor'][zoom>=17] { line-width: @rdz17_service*0.5; }
+    [service='minor'][zoom>=18] { line-width: @rdz18_service*0.5; }
+
+    line-color: @standard-fill;
+    #tunnel { line-color: lighten(@standard-fill, 10%); }
+    [maxspeed_kmh < 33] {
+        line-color: @speed32-fill;
+        #tunnel { line-color: lighten(@speed32-fill, 10%); }
+    }
+    [maxspeed_kmh < 21] {
+        line-color: @speed20-fill;
+        #tunnel { line-color: lighten(@speed20-fill, 10%); }
+    }
+    [maxspeed_kmh < 10] {
+      line-color: @speedWalk-fill;
+      #tunnel { line-color: lighten(@speedWalk-fill, 10%); }
+    }
+    [motor_vehicle='no'][can_bicycle!='no'] {
+        line-color: @nomotor-fill;
+        #tunnel { line-color: lighten(@nomotor-fill, 10%); }
+    }
+    [cyclestreet='yes'] {
+        line-color: @mixed-cycle-fill;
+        #tunnel { line-color: lighten(@mixed-cycle-fill, 10%); }
+    }
+    [can_bicycle='no'] {
+      line-color: @standard-nobicycle;
+      #tunnel { line-color: lighten(@standard-nobicycle, 5%); }
+    }
+
+    //surface
+    //[zoom>=15] {
+      [surface_type='cyclocross'],
+      [surface_type='mtb'] {
+        surface/line-width: @rdz15_service*0.5;
+        [zoom>=16] { surface/line-width: @rdz16_service*0.5; }
+        [zoom>=17] { surface/line-width: @rdz17_service*0.5; }
+        [zoom>=18] { surface/line-width: @rdz18_service*0.5; }
+
+        [surface_type='cyclocross'] {
+          surface/line-opacity: 0.6;
+          surface/line-dasharray: 4,8;
+          [zoom>=16] { surface/line-dasharray: 6,12; }
+          [zoom>=17] { surface/line-dasharray: 8,16; }
+
+          surface/line-color: darken(@standard-fill, @surfaceDarker2); // Darken since it's white.
+          [can_bicycle='no'] { surface/line-color: lighten(@standard-nobicycle, @surfaceLighter1); }
+        }
+
+        [surface_type='mtb'] {
+          surface/line-dasharray: 10,5;
+          [zoom>=16] { surface/line-dasharray: 14,7; }
+          [zoom>=17] { surface/line-dasharray: 20,10; }
+
+          surface/line-color: darken(@standard-fill, @surfaceDarker1); // Darken since its white.
+          [can_bicycle='no'] { surface/line-color: lighten(@standard-nobicycle, @surfaceLighter2); }
+        }
+      }
+    //}
   }
 
   [type='living_street'][zoom>=12] {

--- a/symbols/openstreetmap-carto/amenity/parking.svg
+++ b/symbols/openstreetmap-carto/amenity/parking.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   viewBox="0 0 14 14"
+   height="14"
+   width="14">
+  <rect
+     width="14"
+     height="14"
+     x="0"
+     y="0"
+     id="canvas"
+     visibility="hidden" />
+  <path
+    fill-rule="evenodd"
+    d="m 3,1 0,12 1.75,0 0,-5 L 9,8 A 3,3.5 0 0 0 9,1 Z m 1.75,1.75 0,3.5 3.75,0 a 1.58,1.75 0 0 0 0,-3.5 z" />
+</svg>


### PR DESCRIPTION
Fix of pull request #437 (should replace it).
Fix #372 and should fix also #162.  

Merged with master.
Render minor service roads from z15 like oneway arrow (so no more oneway arrow alone).
Render P icon later at z16 like other common amenities.
Optim style.

![image](https://user-images.githubusercontent.com/47089717/101292836-371ac480-3812-11eb-84c9-89a0effab6cb.png)
![image](https://user-images.githubusercontent.com/47089717/101292848-469a0d80-3812-11eb-8cf7-5803e83fe230.png)
![image](https://user-images.githubusercontent.com/47089717/101292857-59144700-3812-11eb-8122-faccb938b4d6.png)
![image](https://user-images.githubusercontent.com/47089717/101292867-6af5ea00-3812-11eb-9695-2b60b0d5effd.png)
