### PR TITLE
Render floor and ground slot bicycle parking with a dash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     See #464.
 * Add cycle route name.
 * Render parking amenity and servie road parking aisle, drive-through, driveway smaller.
+* Add floor/ground slots bicycle parking.
 
 
 ## v0.3.7

--- a/amenities.mss
+++ b/amenities.mss
@@ -1018,6 +1018,12 @@
       marker-file: url('symbols/amenity/bicycle_parking_covered.svg');
     }
 
+    [bicycle_parking = 'floor'],
+    [bicycle_parking = 'ground_slots'] {
+      marker-file: url('symbols/amenity/bicycle_parking_notlockable.svg');
+      marker-width: 8;
+    }
+
     [supervised = 'yes'],
     [bicycle_parking = 'shed'],
     [bicycle_parking = 'lockers'],

--- a/amenities.mss
+++ b/amenities.mss
@@ -1021,7 +1021,6 @@
     [bicycle_parking = 'floor'],
     [bicycle_parking = 'ground_slots'] {
       marker-file: url('symbols/amenity/bicycle_parking_notlockable.svg');
-      marker-width: 8;
     }
 
     [supervised = 'yes'],

--- a/symbols/amenity/bicycle_parking_notlockable.svg
+++ b/symbols/amenity/bicycle_parking_notlockable.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="64" height="64" viewBox="0 0 64 64" version="1.1" id="svg8" xmlns="http://www.w3.org/2000/svg">
+  <g id="layer1" transform="translate(0,-327.13332)" style="opacity: 0.52;"/>
+  <rect x="22.129" y="32.012" width="19.661" height="8.593" style="fill: rgb(0, 0, 255); stroke: rgb(255, 255, 255); stroke-linecap: round; stroke-width: 3px; stroke-linejoin: round;"/>
+</svg>


### PR DESCRIPTION
Fix #268 

I made the choice of rendering specifically floor and ground slot bicycle parking.
Dash icon is used instead of half circle, it's more easy to distinguish.
I didn't make other icons (covered/secured) since we talking about only 1500 points.

![image](https://user-images.githubusercontent.com/47089717/101929510-3e0d5280-3bd7-11eb-920e-340c02c04c97.png)
