### PR TITLE
Fix island names, draw them with amenities.

### DIFF
--- a/amenities.mss
+++ b/amenities.mss
@@ -1465,6 +1465,30 @@
       text-placement: interior;
     }
   }
+
+  [feature = 'place_island'][zoom >= 14][way_pixels > 3000],
+  [feature = 'place_island'][zoom >= 16],
+  [feature = 'place_islet'][zoom >= 14][way_pixels > 3000],
+  [feature = 'place_islet'][zoom >= 17] {
+    text-name: "[name]";
+    text-fill: @placenames;
+    text-size: 10;
+    text-wrap-width: 30;
+    text-line-spacing: -1.5;
+    [way_pixels > 12000] {
+      text-size: 11;
+      text-wrap-width: 36;
+      text-line-spacing: -1.8;
+    }
+    [way_pixels > 48000] {
+      text-size: 13;
+      text-wrap-width: 45;
+      text-line-spacing: -2.25;
+    }
+    text-face-name: @sans_italic;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @place_halo;
+  }
 }
 
 #trees [zoom >= 16] {

--- a/placenames.mss
+++ b/placenames.mss
@@ -130,33 +130,6 @@
   }
 }
 
-#island-names {
-  [zoom >= 8] {
-    text-name: '[name]';
-    text-face-name: @sans;
-    text-fill: @placenames;
-    text-size: 13;
-    text-wrap-width: 65; // 5.0 em
-    text-line-spacing: -0.65; // -0.05 em
-    text-margin: 9.1; // 0.7 em
-    text-halo-fill: @city_halo;
-    text-halo-radius: @standard-halo-radius * 1.5;
-
-    [zoom >= 10] {
-      text-size: 14;
-      text-wrap-width: 70; // 5.0 em
-      text-line-spacing: -0.70; // -0.05 em
-      text-margin: 9.8; // 0.7 em
-    }
-    [zoom >= 11] {
-      text-size: 15;
-      text-wrap-width: 75; // 5.0 em
-      text-line-spacing: -0.75; // -0.05 em
-      text-margin: 10.5; // 0.7 em
-    }
-  }
-}
-
 #placenames-medium::high-importance {
   [category = 1][zoom < 14] {
     [zoom >= 4][zoom < 5][score >= 3000000],

--- a/project.mml
+++ b/project.mml
@@ -1410,25 +1410,6 @@ Layer:
   properties:
     minzoom: 2
     maxzoom: 14
-- id: island-names
-  geometry: point
-  <<: *extents
-  Datasource:
-    <<: *osm2pgsql
-    table: |-
-      (SELECT
-          way,
-          way_area/NULLIF(!pixel_width!::real*!pixel_height!::real,0) AS way_pixels,
-          name,
-          round(ascii(md5(osm_id::text)) / 55) AS dir -- base direction factor on geometry to be consistent across metatiles
-        FROM planet_osm_polygon
-        WHERE place IN ('island')
-          AND name IS NOT NULL
-        ORDER BY way_area DESC
-      ) AS data
-  properties:
-    minzoom: 3
-    maxzoom: 15
 - id: capital-names
   geometry: point
   <<: *extents
@@ -2178,6 +2159,7 @@ Layer:
               'man_made_' || CASE WHEN man_made IN ('mast', 'tower', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk', 'communications_tower', 'telescope', 'chimney', 'crane', 'storage_tank', 'silo', 'water_tap', 'monitoring_station') THEN man_made ELSE NULL END,
               CASE WHEN tags->'mountain_pass' = 'yes' THEN 'mountain_pass' ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance') THEN "natural" ELSE NULL END,
+              'place_' || CASE WHEN place IN ('island', 'islet') THEN place END,
               'waterway_' || CASE WHEN waterway IN ('waterfall') THEN waterway ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort', 'wayside_shrine', 'castle', 'manor', 'city_gate') THEN historic ELSE NULL END,
               'military_'|| CASE WHEN military IN ('bunker') THEN military ELSE NULL END,
@@ -2249,6 +2231,7 @@ Layer:
             OR man_made IN ('water_tap')
             OR man_made IN ('monitoring_station') AND tags->'monitoring:bicycle'='yes'
             OR "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')
+            OR place IN ('island', 'islet')
             OR tags->'mountain_pass' = 'yes'
             OR waterway IN ('waterfall')
             OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort', 'wayside_shrine', 'castle', 'manor', 'city_gate')
@@ -2328,6 +2311,7 @@ Layer:
               'man_made_' || CASE WHEN man_made IN ('mast', 'tower', 'water_tower', 'lighthouse', 'windmill', 'cross', 'obelisk', 'communications_tower', 'telescope', 'chimney', 'crane', 'storage_tank', 'silo', 'water_tap', 'monitoring_station') THEN man_made ELSE NULL END,
               CASE WHEN tags->'mountain_pass' = 'yes' THEN 'mountain_pass' ELSE NULL END,
               'natural_' || CASE WHEN "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance') THEN "natural" ELSE NULL END,
+              'place_' || CASE WHEN place IN ('island', 'islet') THEN place END,
               'waterway_' || CASE WHEN waterway IN ('waterfall') THEN waterway ELSE NULL END,
               'historic_' || CASE WHEN historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort', 'wayside_shrine', 'castle', 'manor', 'city_gate') THEN historic ELSE NULL END,
               'military_'|| CASE WHEN military IN ('bunker') THEN military ELSE NULL END,
@@ -2415,6 +2399,7 @@ Layer:
             OR man_made IN ('water_tap')
             OR man_made IN ('monitoring_station') AND tags->'monitoring:bicycle'='yes'
             OR "natural" IN ('peak', 'volcano', 'saddle', 'spring', 'cave_entrance')
+            OR place IN ('island', 'islet')
             OR tags->'mountain_pass' = 'yes'
             OR waterway IN ('waterfall')
             OR historic IN ('memorial', 'monument', 'archaeological_site', 'wayside_cross', 'fort', 'wayside_shrine', 'castle', 'manor', 'city_gate')


### PR DESCRIPTION
Fix #474 

Use OSM Carto style, so island size is used to discrimate at which zoom to render.
Add also islet.
Names rendered only from z14, cause of using amenities layers.

![image](https://user-images.githubusercontent.com/47089717/102392714-be68f480-3fd7-11eb-8e78-6fcefd84cb5d.png)
