### PR TITLE
Render highway=construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Render `highway=construction`. See #28.
+
 
 ## v0.4
 

--- a/project.mml
+++ b/project.mml
@@ -451,6 +451,7 @@ Layer:
           way,
           COALESCE(
             CASE
+              WHEN highway='construction' THEN construction
               WHEN highway='raceway' THEN 'track'  -- render raceways as tracks
               WHEN highway='road' THEN 'residential'  -- render "road" as residential
               WHEN highway='trunk' THEN 'motorway'  -- trunk as motorway, check can_bicycle if cyclable
@@ -466,6 +467,7 @@ Layer:
             END
           ) AS type,
           access,
+          CASE WHEN highway='construction' THEN 'yes' ELSE 'no' END AS is_construction,
           layer,
           CASE
             WHEN tags->'maxspeed'~E'^\\d+$' THEN (tags->'maxspeed')::integer
@@ -641,6 +643,7 @@ Layer:
           way,
           COALESCE(
             CASE
+              WHEN highway='construction' THEN construction
               WHEN highway='raceway' THEN 'track'  -- render raceways as tracks
               WHEN highway='road' THEN 'residential'  -- render "road" as residential
               WHEN highway='trunk' THEN 'motorway'  -- trunk as motorway, check can_bicycle if cyclable
@@ -655,6 +658,7 @@ Layer:
               ELSE NULL
             END
           ) AS type,
+          CASE WHEN highway='construction' THEN 'yes' ELSE 'no' END AS is_construction,
           access,
           CASE
             WHEN tags->'maxspeed'~E'^\\d+$' THEN (tags->'maxspeed')::integer
@@ -915,6 +919,7 @@ Layer:
           way,
           COALESCE(
             CASE
+              WHEN highway='construction' THEN construction
               WHEN highway='raceway' THEN 'track'  -- render raceways as tracks
               WHEN highway='road' THEN 'residential'  -- render "road" as residential
               WHEN highway='trunk' THEN 'motorway'  -- trunk as motorway, check can_bicycle if cyclable
@@ -930,6 +935,7 @@ Layer:
             END
           ) AS type,
           access,
+          CASE WHEN highway='construction' THEN 'yes' ELSE 'no' END AS is_construction,
           layer,
           CASE
             WHEN tags->'maxspeed'~E'^\\d+$' THEN (tags->'maxspeed')::integer

--- a/roads.mss
+++ b/roads.mss
@@ -74,6 +74,8 @@
 // * border, on one side (first line is drawn with a width of way with + 2 *
 // * border_width).
 
+@construction_opacity: 0.4;
+
 
 // -- Zoom 11 --
 // Width of ways
@@ -771,6 +773,10 @@
       }
     }
   }
+
+  [is_construction='yes'] {
+    line-opacity: @construction_opacity;
+  }
 }
 
 
@@ -791,6 +797,10 @@
     [oneway='no'][oneway_bicycle='no']{
       line-width: @rdz18_path; line-offset: @rdz18_path/2 + @rdz18_cycle*1.5/2;
     }
+  }
+
+  [is_construction='yes'] {
+    line-opacity: @construction_opacity;
   }
 }
 
@@ -1458,6 +1468,10 @@
       line-width: @rdz18_service;
     }
   }
+
+  [is_construction='yes'] {
+    line-opacity: @construction_opacity;
+  }
 }
 
 #roads_high::cycleway_right[zoom>=18][cycleway_right_render='track'][cycleway_right_oneway='yes'],
@@ -1501,6 +1515,10 @@
     [type='motorway_link']  { marker-transform: translate(0, 0.5 * @rdz18_motorway_link + 0.5 * @rdz18_cycle); }
     [type='service']        { marker-transform: translate(0, 0.5 * @rdz18_service + 0.5 * @rdz18_cycle); }
     [type='pedestrian']     { marker-transform: translate(0, 0.5 * @rdz18_pedestrian + 0.5 * @rdz18_cycle); }
+  }
+
+  [is_construction='yes'] {
+    line-opacity: @construction_opacity;
   }
 }
 
@@ -2169,6 +2187,10 @@
       line-width: @rdz18_service;
     }
   }
+
+  [is_construction='yes'] {
+    line-opacity: @construction_opacity;
+  }
 }
 
 #roads_high::cycleway_left[zoom>=18][cycleway_left_render='track'][cycleway_left_oneway='yes'],
@@ -2212,6 +2234,10 @@
     [type='motorway_link']  { marker-transform: translate(0, -0.5 * @rdz18_motorway_link - 0.5 * @rdz18_cycle); }
     [type='service']        { marker-transform: translate(0, -0.5 * @rdz18_service - 0.5 * @rdz18_cycle); }
     [type='pedestrian']     { marker-transform: translate(0, -0.5 * @rdz18_pedestrian - 0.5 * @rdz18_cycle); }
+  }
+
+  [is_construction='yes'] {
+    line-opacity: @construction_opacity;
   }
 }
 
@@ -3518,6 +3544,13 @@
     [zoom>=16] { line-width: @rdz16_path; }
     [zoom>=17] { line-width: @rdz17_path; }
     [zoom>=18] { line-width: @rdz18_path; }
+  }
+
+  [is_construction='yes'][zoom >= 11] {
+    line-opacity: @construction_opacity;
+    [type='track'], [type='bridleway'], [type='footway'], [type='cycleway'], [type='path'] {
+      background/line-opacity: @construction_opacity;
+    }
   }
 }
 


### PR DESCRIPTION
Hi,

Here is a first draft of render for `highway=construction` tag as discussed in #28. I'm only playing on opacity so far, since playing with dash would make it difficult to read and risk inducing confusion with the already dashed items (cycleway, footway, etc).

Some examples below:

https://www.openstreetmap.org/way/667390515#map=19/45.77706/3.07498
![2021-01-03-143842](https://user-images.githubusercontent.com/3856586/103479945-67359300-4dd1-11eb-870b-f2ecbd635e6e.png)


https://www.openstreetmap.org/way/854996738#map=17/46.14530/3.42974
![2021-01-03-143911](https://user-images.githubusercontent.com/3856586/103479955-774d7280-4dd1-11eb-9ee5-637362424a57.png)


Render is not perfect, I identified two issues:

1. Playing with opacity makes the road appear grey-er than it should (due to opacity not being applied to the whole object but layer by layer and hence grey is made of semi-opaque white on top of grey outline).
2. Junctions are not rendered nicely (see roundabout).

This however does seem fine to me for a first render and convey the necessary information about "this is a construction area, you might or not be able to cross".

Best,