### PR TITLE
Add dashline outline on path like way tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 * Render more features at low zoom: land, water and hillshades at zoom 3 and 4. See #494.
+* Add dashline outline on path like way tunnels.
 
 ## v0.4
 

--- a/road-colors.mss
+++ b/road-colors.mss
@@ -54,6 +54,7 @@
 @track-light2: lighten(@track-fill, 50);
 
 @bridge_case: #666;
+@bridge_path_case: @land;
 
 @aeroway: #ddd;
 

--- a/roads.mss
+++ b/roads.mss
@@ -371,7 +371,7 @@
 @rdz18_service_outline: 1.75;
 @rdz18_pedestrian_outline: 4;
 @rdz18_steps_outline: 1;
-@rdz18_line_bridge_outline: 1;  // cycleway, footway, bridleway, path on bridges
+@rdz18_line_bridge_outline: 1.5;  // cycleway, footway, bridleway, path on bridges
 
 // ---- Rail background with hatches -------------------------
 
@@ -740,15 +740,49 @@
     [zoom>=18] { line-width: @rdz18_service*0.5 + @rdz18_service_outline; }
   }
 
+  #tunnel::outline {
+    [zoom>=17] {
+      [type='bridleway'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz17_bridleway + (2 * @rdz17_line_bridge_outline); }
+      [type='footway'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz17_footway + (2 * @rdz17_line_bridge_outline); }
+      [type='path'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz17_path + (2 * @rdz17_line_bridge_outline); }
+      [type='cycleway'],
+      [type='path'][can_bicycle='designated'] {
+        line-dasharray: 3,3;
+        line-cap: butt;
+        line-color: @bridge_case;
+        line-width: @rdz17_cycle + (2 * @rdz17_line_bridge_outline);
+        [oneway='no'][oneway_bicycle='no'] {
+          line-width: @rdz17_cycle*1.5 + (2 * @rdz17_line_bridge_outline);
+        }
+      }
+
+      [zoom >= 18] {
+        [type='bridleway'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz18_bridleway + (2 * @rdz18_line_bridge_outline); }
+        [type='footway'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz18_footway + (2 * @rdz18_line_bridge_outline); }
+        [type='path'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz18_path + (2 * @rdz18_line_bridge_outline); }
+        [type='cycleway'],
+        [type='path'][can_bicycle='designated'] {
+          line-dasharray: 3,3;
+          line-cap: butt;
+          line-color: @bridge_case;
+          line-width: @rdz18_cycle + (2 * @rdz18_line_bridge_outline);
+          [oneway='no'][oneway_bicycle='no'] {
+            line-width: @rdz18_cycle*1.5 + (2 * @rdz18_line_bridge_outline);
+          }
+        }
+      }
+    }
+  }
+  
   #bridge::outline {
     [zoom>=17] {
-      [type='bridleway'] { line-cap: butt; line-color: @land; line-width: @rdz17_bridleway + (2 * @rdz17_line_bridge_outline); }
-      [type='footway'] { line-cap: butt; line-color: @land; line-width: @rdz17_footway + (2 * @rdz17_line_bridge_outline); }
-      [type='path'] { line-cap: butt; line-color: @land; line-width: @rdz17_path + (2 * @rdz17_line_bridge_outline); }
+      [type='bridleway'] { line-cap: butt; line-color: @bridge_path_case; line-width: @rdz17_bridleway + (2 * @rdz17_line_bridge_outline); }
+      [type='footway'] { line-cap: butt; line-color: @bridge_path_case; line-width: @rdz17_footway + (2 * @rdz17_line_bridge_outline); }
+      [type='path'] { line-cap: butt; line-color: @bridge_path_case; line-width: @rdz17_path + (2 * @rdz17_line_bridge_outline); }
       [type='cycleway'],
       [type='path'][can_bicycle='designated'] {
         line-cap: butt;
-        line-color: @land;
+        line-color: @bridge_path_case;
         line-width: @rdz17_cycle + (2 * @rdz17_line_bridge_outline);
         [oneway='no'][oneway_bicycle='no'] {
           line-width: @rdz17_cycle*1.5 + (2 * @rdz17_line_bridge_outline);
@@ -757,13 +791,13 @@
     }
 
     [zoom >= 18] {
-      [type='bridleway'] { line-cap: butt; line-color: @land; line-width: @rdz18_bridleway + (2 * @rdz18_line_bridge_outline); }
-      [type='footway'] { line-cap: butt; line-color: @land; line-width: @rdz18_footway + (2 * @rdz18_line_bridge_outline); }
-      [type='path'] { line-cap: butt; line-color: @land; line-width: @rdz18_path + (2 * @rdz18_line_bridge_outline); }
+      [type='bridleway'] { line-cap: butt; line-color: @bridge_path_case; line-width: @rdz18_bridleway + (2 * @rdz18_line_bridge_outline); }
+      [type='footway'] { line-cap: butt; line-color: @bridge_path_case; line-width: @rdz18_footway + (2 * @rdz18_line_bridge_outline); }
+      [type='path'] { line-cap: butt; line-color: @bridge_path_case; line-width: @rdz18_path + (2 * @rdz18_line_bridge_outline); }
       [type='cycleway'],
       [type='path'][can_bicycle='designated'] {
         line-cap: butt;
-        line-color: @land;
+        line-color: @bridge_path_case;
         line-width: @rdz18_cycle + (2 * @rdz18_line_bridge_outline);
         [oneway='no'][oneway_bicycle='no'] {
           line-width: @rdz18_cycle*1.5 + (2 * @rdz18_line_bridge_outline);

--- a/roads.mss
+++ b/roads.mss
@@ -742,9 +742,9 @@
 
   #tunnel::outline {
     [zoom>=17] {
-      [type='bridleway'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz17_bridleway + (2 * @rdz17_line_bridge_outline); }
-      [type='footway'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz17_footway + (2 * @rdz17_line_bridge_outline); }
-      [type='path'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz17_path + (2 * @rdz17_line_bridge_outline); }
+      [type='bridleway'] { line-dasharray: 3,3; line-cap: butt; line-color: @bridge_case; line-width: @rdz17_bridleway + (2 * @rdz17_line_bridge_outline); }
+      //[type='footway'] { line-dasharray: 3,3; line-cap: butt; line-color: @bridge_case; line-width: @rdz17_footway + (2 * @rdz17_line_bridge_outline); }
+      [type='path'] { line-dasharray: 3,3; line-cap: butt; line-color: @bridge_case; line-width: @rdz17_path + (2 * @rdz17_line_bridge_outline); }
       [type='cycleway'],
       [type='path'][can_bicycle='designated'] {
         line-dasharray: 3,3;
@@ -757,9 +757,9 @@
       }
 
       [zoom >= 18] {
-        [type='bridleway'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz18_bridleway + (2 * @rdz18_line_bridge_outline); }
-        [type='footway'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz18_footway + (2 * @rdz18_line_bridge_outline); }
-        [type='path'] { line-cap: butt; line-color: @bridge_case; line-width: @rdz18_path + (2 * @rdz18_line_bridge_outline); }
+        [type='bridleway'] { line-dasharray: 3,3; line-cap: butt; line-color: @bridge_case; line-width: @rdz18_bridleway + (2 * @rdz18_line_bridge_outline); }
+        //[type='footway'] { line-dasharray: 3,3; line-cap: butt; line-color: @bridge_case; line-width: @rdz18_footway + (2 * @rdz18_line_bridge_outline); }
+        [type='path'] { line-dasharray: 3,3; line-cap: butt; line-color: @bridge_case; line-width: @rdz18_path + (2 * @rdz18_line_bridge_outline); }
         [type='cycleway'],
         [type='path'][can_bicycle='designated'] {
           line-dasharray: 3,3;
@@ -773,7 +773,7 @@
       }
     }
   }
-  
+
   #bridge::outline {
     [zoom>=17] {
       [type='bridleway'] { line-cap: butt; line-color: @bridge_path_case; line-width: @rdz17_bridleway + (2 * @rdz17_line_bridge_outline); }

--- a/roads.mss
+++ b/roads.mss
@@ -3383,7 +3383,7 @@
     line-cap: round;
     line-join: round;
     line-color: @cycle-fill;
-    #tunnel { line-color: lighten(@cycle-fill, 15%); }
+    #tunnel { line-color: lighten(@cycle-fill, 25%); }
 
     [can_bicycle='no'] {
       line-color: @standard-nobicycle;
@@ -3496,15 +3496,15 @@
     line-cap: round;
     line-join: round;
     line-color: @path-fill;
-    #tunnel { line-color: lighten(@path-fill, 10%); }
+    #tunnel { line-color: lighten(@path-fill, 15%); }
 
     [can_bicycle='designated'] {
       line-color: @mixed-cycle-fill;
-      #tunnel { line-color: lighten(@mixed-cycle-fill, 10%); }
+      #tunnel { line-color: lighten(@mixed-cycle-fill, 15%); }
 
       [segregated='yes'] {
         line-color: @cycle-fill;
-        #tunnel { line-color: lighten(@cycle-fill, 15%); }
+        #tunnel { line-color: lighten(@cycle-fill, 25%); }
       }
 
       line-width: @rdz11_cycle;


### PR DESCRIPTION
#fix #492 

![Screenshot_20210120_230251](https://user-images.githubusercontent.com/47089717/105246999-609a7000-5b74-11eb-973d-30aa9e9f37c2.png)
![Screenshot_20210120_230230](https://user-images.githubusercontent.com/47089717/105247003-61330680-5b74-11eb-8675-e6a370b43907.png)
![Screenshot_20210120_230156](https://user-images.githubusercontent.com/47089717/105247005-61330680-5b74-11eb-870b-0a5d4a0c93a0.png)

The outline for bridges is also little wider.
![Screenshot_20210120_230030](https://user-images.githubusercontent.com/47089717/105247007-61cb9d00-5b74-11eb-9999-0df006f67d41.png)
