### PR TITLE
Remove rail background at z<=11 to avoid them hidding cycleways.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Render more features at low zoom: land, water and hillshades at zoom 3 and 4. See #494.
 * Fix, render as road bike surface tracktype=grade1 and good smoothness.
 * Render dam #481.
+* Fix cycleway hidded by rail background #451.
 
 ## v0.4
 

--- a/roads.mss
+++ b/roads.mss
@@ -378,13 +378,6 @@
 #roads_high[zoom>=11],
 #bridge[zoom>=11] {
     [type='railway']::rail_perpendicular {
-
-        /* background: to avoid weird pattern when many tracks are overlapping */
-        [zoom<14] {
-            background/line-color: @land;
-            background/line-width: 3;
-        }
-
         line-color: @rail-line;
         line-cap: butt;
 


### PR DESCRIPTION
fix  #451

It's little more noisier but I think it's ok :

![Screenshot_20210122_191525](https://user-images.githubusercontent.com/47089717/105529884-5ea4ee00-5ce7-11eb-812b-c7cca3ae1797.png)
![Screenshot_20210122_191429](https://user-images.githubusercontent.com/47089717/105529891-5f3d8480-5ce7-11eb-88e0-756158843e80.png)
![Screenshot_20210122_191323](https://user-images.githubusercontent.com/47089717/105529893-5fd61b00-5ce7-11eb-82c3-11367e2d1eca.png)
![Screenshot_20210122_191310](https://user-images.githubusercontent.com/47089717/105529895-5fd61b00-5ce7-11eb-8d29-fd05bb597a5e.png)
