### PR TITLE
Render living street with 20km/h speed limit color by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix ford on node not rendered #508.
 * Use blue shared cycle path for bus/cycle lane #356.
 * Add bicycle leisure track for areas.
+* Render living street with 20km/h color by default #238.
 
 
 ## v0.4

--- a/roads.mss
+++ b/roads.mss
@@ -3063,19 +3063,19 @@
     [zoom>=17] { line-width: @rdz17_living_street; }
     [zoom>=18] { line-width: @rdz18_living_street; }
 
-    line-color: @standard-fill;
-    #tunnel { line-color: lighten(@standard-fill, 10%); }
-    [maxspeed_kmh < 33] {
-        line-color: @speed32-fill;
-        #tunnel { line-color: lighten(@speed32-fill, 10%); }
-    }
-    [maxspeed_kmh < 21] {
-        line-color: @speed20-fill;
-        #tunnel { line-color: lighten(@speed20-fill, 10%); }
-    }
+    line-color: @speed20-fill;
+    #tunnel { line-color: lighten(@speed20-fill, 10%); }
     [maxspeed_kmh < 10] {
       line-color: @speedWalk-fill;
       #tunnel { line-color: lighten(@speedWalk-fill, 10%); }
+    }
+    [maxspeed_kmh >= 21] {
+        line-color: @speed32-fill;
+        #tunnel { line-color: lighten(@speed32-fill, 10%); }
+    }
+    [maxspeed_kmh >= 33] {
+        line-color: @standard-fill;
+        #tunnel { line-color: lighten(@standard-fill, 10%); }
     }
     [motor_vehicle='no'][can_bicycle!='no'] {
         line-color: @nomotor-fill;
@@ -3134,17 +3134,17 @@
 
     line-color: @pedestrian-fill;
     #tunnel { line-color: lighten(@pedestrian-fill, 10%); }
-    [maxspeed_kmh < 33] {
+    [maxspeed_kmh >= 10] {
+      line-color: @speed20-fill;
+      #tunnel { line-color: lighten(@speed20-fill, 10%); }
+    }
+    [maxspeed_kmh >= 21] {
         line-color: @speed32-fill;
         #tunnel { line-color: lighten(@speed32-fill, 10%); }
     }
-    [maxspeed_kmh < 21] {
-        line-color: @speed20-fill;
-        #tunnel { line-color: lighten(@speed20-fill, 10%); }
-    }
-    [maxspeed_kmh < 10] {
-      line-color: @speedWalk-fill;
-      #tunnel { line-color: lighten(@speedWalk-fill, 10%); }
+    [maxspeed_kmh >= 33] {
+        line-color: @standard-fill;
+        #tunnel { line-color: lighten(@standard-fill, 10%); }
     }
     //  [motor_vehicle='no'][can_bicycle!='no'][type!='pedestrian'] { //Keep pedestrian color even if motor is forbidden.
     //    line-color: @nomotor-fill;


### PR DESCRIPTION
Fix also pedestrian color with maxspeed higher than 30km/h.

fix #238 