### PR TITLE
contour style rework #534

### DIFF
--- a/base.mss
+++ b/base.mss
@@ -385,78 +385,50 @@ Map { background-color: @water; }
 /* ================================================================== */
 .contours {
   line-color: @contours-stroke;
+  line-comp-op : multiply;
+  [zoom >= 14] { line-smooth: 0.5; }
 
   /* 100 m */
   #contours100 {
-    [zoom >= 11] { line-width: 0.2; }
-    [zoom >= 12] { line-width: 0.4; }
-    [zoom >= 13] { line-width: 0.5; }
-    [zoom >= 14] { line-width: 0.6; line-smooth: 0.5; }
-    [zoom >= 16] { line-width: 1; }
+    [zoom >= 11] { line-width: 1.6 * 0.30; }
+    [zoom >= 14] { line-width: 1.6 * 0.38; }
+    [zoom >= 16] { line-width: 1.6 * 0.45; }
+    [zoom >= 18] { line-width: 1.6 * 0.60; }
   }
 
   /* 50 m */
   #contours50 {
-    [zoom >= 11] { line-width: 0.2; }
-    [zoom >= 13] { line-width: 0.3; }
-    [zoom >= 14] { line-width: 0.4; line-smooth: 0.5; }
-    [zoom >= 16] { line-width: 0.8; line-smooth: 0.5; }
-
-    [zoom = 14] {
-      text-face-name: @sans_bold;
-      text-size: @contours-font-size;
-      text-fill: @contours-fill;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @contours-halo-fill;
-      text-placement: line;
-      text-label-position-tolerance: @contours-position-tolerance;
-      text-spacing: @contours-small-spacing;
-      text-min-path-length: @contours-small-min-path-length;
-      text-max-char-angle-delta: @contours-max-char-angle-delta;
-      text-name: "[height]";
-    }
+    [zoom >= 11] { line-width: 1.4 * 0.30; }
+    [zoom >= 14] { line-width: 1.4 * 0.38; }
+    [zoom >= 16] { line-width: 1.4 * 0.45; }
+    [zoom >= 18] { line-width: 1.4 * 0.60; }
   }
 
-  /* 20 m */
+  /* 10 m, 20 m */
+  #contours10,
   #contours20 {
-    [zoom >= 12] { line-width: 0.2; line-smooth: 0.5; }
-    [zoom >= 16] { line-width: 0.4; }
-  }
-
-  /* 10m */
-  #contours10 {
-    [zoom >= 13] { line-width: 0.2; line-smooth: 0.5; }
-    [zoom >= 15] {
-      text-face-name: @standard-font;
-      text-size: @contours-font-size;
-      text-fill: @contours-fill;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @contours-halo-fill;
-      text-placement: line;
-      text-label-position-tolerance: @contours-position-tolerance;
-      text-spacing: @contours-spacing;
-      text-min-path-length: @contours-min-path-length;
-      text-max-char-angle-delta: @contours-max-char-angle-delta;
-      text-name: "[height]";
-    }
-    [zoom >= 16] { line-width: 0.4; }
+    [zoom >= 11] { line-width: 1.0 * 0.30; }
+    [zoom >= 14] { line-width: 1.0 * 0.38; }
+    [zoom >= 16] { line-width: 1.0 * 0.45; }
+    [zoom >= 18] { line-width: 1.0 * 0.60; }
   }
 
   /* All labels */
-  #contours100, #contours50, #contours10 {
-    [zoom >= 16] {
-      text-face-name: @standard-font;
-      text-size: @contours-larger-font-size;
-      text-fill: @contours-fill;
-      text-halo-radius: @standard-halo-radius;
-      text-halo-fill: @contours-halo-fill;
-      text-placement: line;
-      text-label-position-tolerance: @contours-position-tolerance;
-      text-spacing: @contours-spacing;
-      text-min-path-length: @contours-min-path-length;
-      text-max-char-angle-delta: @contours-max-char-angle-delta;
-      text-name: "[height]";
-    }
+  #contours100[zoom >= 14],
+  #contours50[zoom >= 15],
+  #contours20[zoom >= 16],
+  #contours10[zoom >= 16] {
+    text-face-name: @standard-font;
+    text-size: @contours-larger-font-size;
+    text-fill: @contours-fill;
+    text-halo-radius: @standard-halo-radius;
+    text-halo-fill: @contours-halo-fill;
+    text-placement: line;
+    text-label-position-tolerance: @contours-position-tolerance;
+    text-spacing: @contours-spacing;
+    text-min-path-length: @contours-min-path-length;
+    text-max-char-angle-delta: @contours-max-char-angle-delta;
+    text-name: "[height]";
   }
 }
 

--- a/palette.mss
+++ b/palette.mss
@@ -134,7 +134,7 @@
 @major-highway-text-repeat-distance: 300;
 @minor-highway-text-repeat-distance: 150;
 
-@contours-halo-fill: rgba(0, 0, 0, 0.3);
+@contours-halo-fill: rgba(255,255,255,0.5);
 @contours-font-size: 8;
 @contours-larger-font-size: 9;
 @contours-position-tolerance: 100;
@@ -143,8 +143,8 @@
 @contours-small-min-path-length: 200;
 @contours-min-path-length: 300;
 @contours-max-char-angle-delta: 10;
-@contours-fill: #ffa970;
-@contours-stroke: #c45700;
+@contours-fill: #997744;
+@contours-stroke: #DDBB00;
 
 /* ================================================================== */
 /* POIs COLORS


### PR DESCRIPTION
Hello,
Here is my try to improve contour lines style :
- thinner and more yellowish to make confusion with path impossible
- comp-op multiply to make them visible on both empty land, forest, or even hill shadow background, 
- less labels at mid-zoom
- label glow is now white

I didn't manage to download elevation data, I simply drawn some lines by hand in JOSM for testing purpose...

![Screen Shot 2021-05-10 at 10 08 20](https://user-images.githubusercontent.com/3080387/117565502-f0c3dd00-b0b1-11eb-9794-a3db03f791da.png)
![Screen Shot 2021-05-10 at 10 08 50](https://user-images.githubusercontent.com/3080387/117565505-f15c7380-b0b1-11eb-94e5-83349da6c939.png)
![Screen Shot 2021-05-10 at 10 10 22](https://user-images.githubusercontent.com/3080387/117565506-f1f50a00-b0b1-11eb-929e-a3a34cc08602.png)
![Screen Shot 2021-05-10 at 10 10 52](https://user-images.githubusercontent.com/3080387/117565508-f28da080-b0b1-11eb-9eca-196bb027dae1.png)



