### PR TITLE
Remove and fade minor railway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fix missing POIs: swimming pools, `shop=doityourself` and schools. Fix #64.
 * Render train stations when tagged on buildings (polygons). Fix #527.
 * Rendering bridge surface. Fix #551.
+* Remove rendering of minor railway (spur, siding, yard) at low zooms, fade them for higher zooms. Fix #559.
 
 
 ## v0.5

--- a/project.mml
+++ b/project.mml
@@ -796,7 +796,7 @@ Layer:
             ELSE 'unknown'
           END AS surface_type,
           CASE
-            WHEN service in ('parking_aisle', 'drive-through', 'driveway') THEN 'minor'
+            WHEN service in ('parking_aisle', 'drive-through', 'driveway', 'spur', 'siding', 'yard') THEN 'minor'
             ELSE service
           END AS service,
           CASE
@@ -1076,7 +1076,7 @@ Layer:
             ELSE 'unknown'
           END AS surface_type,
           CASE
-            WHEN service in ('parking_aisle', 'drive-through', 'driveway') THEN 'minor'
+            WHEN service in ('parking_aisle', 'drive-through', 'driveway', 'spur', 'siding', 'yard') THEN 'minor'
             ELSE service
           END AS service,
           CASE

--- a/project.mml
+++ b/project.mml
@@ -850,8 +850,8 @@ Layer:
             ELSE NULL
           END AS can_bicycle
         FROM planet_osm_roads
-        WHERE (railway IN ('rail')
-            OR highway IN ('motorway', 'trunk', 'primary', 'secondary'))
+        WHERE (((railway IN ('rail') AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))
+            OR highway IN ('motorway', 'trunk', 'primary', 'secondary')))
           AND way && !bbox!
         ORDER BY CASE
           WHEN railway IS NOT NULL THEN 0
@@ -881,7 +881,8 @@ Layer:
             tunnel,
             bicycle
           FROM planet_osm_roads
-          WHERE (railway IN ('rail') OR highway IN ('motorway', 'trunk'))
+          WHERE ((railway IN ('rail') AND (service IS NULL OR service NOT IN ('spur', 'siding', 'yard')))
+              OR highway IN ('motorway', 'trunk'))
             AND way && !bbox!
           ORDER BY CASE
             WHEN railway IS NOT NULL THEN 0

--- a/roads.mss
+++ b/roads.mss
@@ -378,8 +378,14 @@
 #roads_high[zoom>=11],
 #bridge[zoom>=11] {
     [type='railway']::rail_perpendicular {
-        line-color: @rail-line;
+      [service!='minor'],
+      [service='minor'][zoom>=13]
+      {
         line-cap: butt;
+        line-color: @rail-line;
+        [service='minor'] {
+          line-color: lighten(@rail-line, 25%);
+        }
 
         /* hatches: start with space to avoid dense pattern on very short ways */
         line-dasharray: 0,2,1,2;
@@ -387,6 +393,7 @@
 
         line-width: 3;
         [zoom>=19] { line-width: 6; }
+      }
     }
 }
 
@@ -3677,29 +3684,36 @@
 #roads_high::rail_line[zoom>=11],
 #bridge::rail_line[zoom>=11] {
   [type='railway'] {
-    line-color: @rail-line;
+    [service!='minor'],
+    [service='minor'][zoom>=13]
+    {
+      line-color: @rail-line;
+      [service='minor'] {
+        line-color: lighten(@rail-line, 25%);
+      }
 
-    line-width: @rdz11_railway;
-    [zoom>=12] {
-      line-width: @rdz12_railway;
-    }
-    [zoom>=13] {
-      line-width: @rdz13_railway;
-    }
-    [zoom>=14] {
-      line-width: @rdz14_railway;
-    }
-    [zoom>=15] {
-      line-width: @rdz15_railway;
-    }
-    [zoom>=16] {
-      line-width: @rdz16_railway;
-    }
-    [zoom>=17] {
-      line-width: @rdz17_railway;
-    }
-    [zoom>=18] {
-      line-width: @rdz18_railway;
+      line-width: @rdz11_railway;
+      [zoom>=12] {
+        line-width: @rdz12_railway;
+      }
+      [zoom>=13] {
+        line-width: @rdz13_railway;
+      }
+      [zoom>=14] {
+        line-width: @rdz14_railway;
+      }
+      [zoom>=15] {
+        line-width: @rdz15_railway;
+      }
+      [zoom>=16] {
+        line-width: @rdz16_railway;
+      }
+      [zoom>=17] {
+        line-width: @rdz17_railway;
+      }
+      [zoom>=18] {
+        line-width: @rdz18_railway;
+      }
     }
   }
 }


### PR DESCRIPTION
Remove railway with tag service=yard|siding|spur from z<13
Fade them from z13

Fix #559, didn't use usage tag, its seems not worth it, service take most of minor railways.

![Screenshot_20210514_191529](https://user-images.githubusercontent.com/47089717/118306045-1fdeb200-b4e9-11eb-8a24-167b312cfc72.png)
![Screenshot_20210514_191449](https://user-images.githubusercontent.com/47089717/118306048-20774880-b4e9-11eb-9fe6-42ac511effaf.png)
![Screenshot_20210514_191406](https://user-images.githubusercontent.com/47089717/118306050-210fdf00-b4e9-11eb-8cd9-f8d24cff7a1b.png)
![Screenshot_20210514_180232](https://user-images.githubusercontent.com/47089717/118306036-1bb29480-b4e9-11eb-88d6-8b856c3adf00.png)
