### PR TITLE
Agricultural/forestry roads should not be considered bikable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Agricultural / forestry roads are not allowed to bicycles. See https://discuss.graphhopper.com/t/bicycle-allowed-on-vehicle-delivery-or-vehicle-forestry/6983/3
 * Track width at z14 was smaller than in other zoom levels. See #411.
 * Add a thin contour on buildings at mid zooms. See #411.
 * Ensure bicycle crossing are drawn at crossings with highway=service. See #503.

--- a/views.sql
+++ b/views.sql
@@ -101,7 +101,7 @@ CREATE VIEW cyclosm_ways AS
             WHEN bicycle IS NOT NULL THEN bicycle
             WHEN tags->'motorroad' IN ('yes') THEN 'no'
             WHEN highway IN ('motorway', 'motorway_link', 'busway') THEN 'no'
-            WHEN tags->'vehicle' IN ('no', 'private') THEN 'no'
+            WHEN tags->'vehicle' IN ('no', 'private', 'restricted', 'military', 'emergency', 'agricultural', 'forestry', 'delivery') THEN 'no'
             WHEN tags->'vehicle' IS NOT NULL THEN tags->'vehicle'
             WHEN access IN ('no', 'private') THEN 'no'
             WHEN access IS NOT NULL THEN access


### PR DESCRIPTION
As reported by a user:

> It has come to my attention that for Austria CyclOSM is not rendering
roads marked as vehicle=forestry correctly. According to Austrian law,
forestry roads are not allowed for bicycles, unless specifically
dedicated for them by signage. CyclOSM is not making a difference
though, between roads tagged as vehicle=forestry and roads not tagged
this access-tag.

See
https://discuss.graphhopper.com/t/bicycle-allowed-on-vehicle-delivery-or-vehicle-forestry/6983/3
as well.