### PR TITLE
Add fallback values for oneway_bicycle to views.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ensure bicycle crossing are drawn at crossings with highway=service. See #503.
 * Handle `cycleway:left|right:oneway=-1` as aliases of
     `cycleway:left|right=opposite_lane`. See #555.
+* Cycleways and bicycle-designated pats with no oneway tag are now drawn like a 
+    cycleway/path with oneway=no tag. See #601
 
 
 ## v0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Ensure bicycle crossing are drawn at crossings with highway=service. See #503.
 * Handle `cycleway:left|right:oneway=-1` as aliases of
     `cycleway:left|right=opposite_lane`. See #555.
-* Cycleways and bicycle-designated pats with no oneway tag are now drawn like a 
+* Cycleways and bicycle-designated paths with no oneway tag are now drawn like a 
     cycleway/path with oneway=no tag. See #601
 
 

--- a/views.sql
+++ b/views.sql
@@ -49,7 +49,7 @@ CREATE VIEW cyclosm_ways AS
         END AS cyclestreet,
         CASE
             WHEN oneway IN ('yes', '-1') THEN oneway
-            WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
+            WHEN junction IN ('roundabout') AND (oneway IS NULL OR oneway NOT IN ('no', 'reversible')) THEN 'yes'
             ELSE 'no'
         END AS oneway,
         CASE

--- a/views.sql
+++ b/views.sql
@@ -120,7 +120,7 @@ CREATE VIEW cyclosm_ways AS
               OR tags->'cycleway:left:oneway'='-1' OR tags->'cycleway:right:oneway'='-1'
                 THEN 'no'
             WHEN oneway IN ('yes', '-1') THEN oneway
-            WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
+            WHEN junction IN ('roundabout') AND (oneway IS NULL OR oneway NOT IN ('no', 'reversible')) THEN 'yes'
             ELSE 'no'
         END AS oneway_bicycle,
         COALESCE(

--- a/views.sql
+++ b/views.sql
@@ -113,14 +113,15 @@ CREATE VIEW cyclosm_ways AS
         END AS segregated,
         CASE
             WHEN tags->'oneway:bicycle' IS NOT NULL THEN tags->'oneway:bicycle'
-            WHEN highway='cycleway' AND oneway IS NOT NULL THEN oneway
             WHEN tags->'cycleway' IN ('opposite', 'opposite_lane', 'opposite_track', 'opposite_share_busway')
               OR tags->'cycleway:both' IN ('opposite', 'opposite_lane', 'opposite_track', 'opposite_share_busway')
               OR tags->'cycleway:left' IN ('opposite', 'opposite_lane', 'opposite_track', 'opposite_share_busway')
               OR tags->'cycleway:right' IN ('opposite', 'opposite_lane', 'opposite_track', 'opposite_share_busway')
               OR tags->'cycleway:left:oneway'='-1' OR tags->'cycleway:right:oneway'='-1'
                 THEN 'no'
-            ELSE NULL
+            WHEN oneway IN ('yes', '-1') THEN oneway
+            WHEN junction IN ('roundabout') AND (oneway IS NULL OR NOT oneway IN ('no', 'reversible')) THEN 'yes'
+            ELSE 'no'
         END AS oneway_bicycle,
         COALESCE(
             tags->'ramp:bicycle',


### PR DESCRIPTION
Cycleways and paths without a oneway tag will now be rendered identically a path/cycleway with a oneway=no tag. Fxes #601

The following screenshot from around https://www.cyclosm.org/#map=18/50.73743/7.07980/cyclosm
Before:
![Before](https://user-images.githubusercontent.com/35740782/176969433-62ca417e-6527-47d4-8d2c-0a88bb52d587.png)
After:
![After](https://user-images.githubusercontent.com/35740782/176969436-c00fff56-38db-45f2-8516-32529b92b6a5.png)


 