### PR TITLE
Add aerialway = magic_carpet to 

### DIFF
--- a/aerialways.mss
+++ b/aerialways.mss
@@ -84,6 +84,7 @@
   [aerialway = 'j-bar'],
   [aerialway = 'platter'],
   [aerialway = 'rope_tow'],
+  [aerialway = 'magic_carpet'],
   [aerialway = 'zip_line'] {
     [zoom >= 12] {
       line/line-width: 1;


### PR DESCRIPTION
Changes proposed in this pull request:

    add magic_carpet to aerialways.mss, because it doesn't get rendered.
Magic Carpets are people movers in ski resorts. It's good to render them in biking maps for quick reference and they are obstacles in the mountain.
Test rendering with link to the example place:
https://www.cyclosm.org/#map=17/40.33043/-7.61274/cyclosm

In this place there is a not rendered magic carpet.