### PR TITLE
Optimize Z9 rendering

### DIFF
--- a/base.mss
+++ b/base.mss
@@ -17,8 +17,8 @@
   polygon-gamma: 0.75;
 }
 
-#landuse_gen0[zoom>1][zoom<=9],
-#landuse_gen1[zoom>9][zoom<=12],
+#landuse_gen0[zoom>1][zoom<=8],
+#landuse_gen1[zoom>8][zoom<=12],
 #landuse[zoom>=13] {
   [type='amenity_grave_yard'],
   [type='landuse_cemetery'] {

--- a/project.mml
+++ b/project.mml
@@ -84,7 +84,7 @@ Layer:
             CASE WHEN "natural" IS NOT NULL THEN ('natural_' || "natural") ELSE NULL END,
             CASE WHEN leisure IS NOT NULL THEN ('leisure_' || leisure) ELSE NULL END,
             CASE WHEN amenity IS NOT NULL THEN ('amenity_' || amenity) ELSE NULL END,
-            CASE WHEN highway IN ('pedestrian') THEN ('highway_' || highway) ELSE NULL END
+            CASE WHEN highway IS NOT NULL THEN ('highway_' || highway) ELSE NULL END
           ) AS type,
           sport
           FROM planet_osm_polygon
@@ -102,7 +102,7 @@ Layer:
   geometry: polygon
   properties:
     minzoom: 2
-    maxzoom: 9
+    maxzoom: 8
 - id: landuse_gen1
   <<: *extents
   Datasource:
@@ -129,12 +129,13 @@ Layer:
           OR highway IN ('pedestrian')
         )
         AND way_area > 1*!pixel_width!::real*!pixel_height!::real
+        AND way && !bbox!
         ORDER BY way_area DESC
       ) AS data
   geometry: polygon
   properties:
     cache-features: true
-    minzoom: 10
+    minzoom: 9
     maxzoom: 12
 - id: landuse
   <<: *extents
@@ -182,6 +183,7 @@ Layer:
           ("natural" = 'wood' OR landuse = 'forest')
           AND building IS NULL
           AND way_area > 1*!pixel_width!::real*!pixel_height!::real
+          AND way && !bbox!
         ORDER BY way_area DESC
       ) AS data
   geometry: polygon
@@ -336,6 +338,7 @@ Layer:
             OR landuse in ('basin', 'reservoir')
           )
           AND way_area > 0.1*!pixel_width!::real*!pixel_height!::real
+          AND way && !bbox!
           AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert'))
       ) AS data
   geometry: polygon
@@ -363,6 +366,7 @@ Layer:
             OR landuse in ('basin', 'reservoir')
           )
           AND way_area > 1*!pixel_width!::real*!pixel_height!::real
+          AND way && !bbox!
           AND (tunnel IS NULL OR tunnel NOT IN ('yes', 'culvert'))
       ) AS data
   geometry: polygon
@@ -924,6 +928,7 @@ Layer:
                 OR (boundary = 'protected_area' AND tags->'protect_class' IN ('1','1a','1b','2','3','4','5','6','7','24','97','98','99')))
           AND building IS NULL
           AND way_area > 1*!pixel_width!::real*!pixel_height!::real
+          AND way && !bbox!
       ) AS protected_areas
   properties:
     cache-features: true
@@ -1920,6 +1925,7 @@ Layer:
           (landuse = 'military' OR military = 'danger_area')
           AND building IS NULL
           AND way_area > 1*!pixel_width!::real*!pixel_height!::real
+          AND way && !bbox!
         ORDER BY way_area DESC
       ) AS data
   geometry: polygon


### PR DESCRIPTION
Z9 was quite anomaly in terms of rendering time. It was taking much longer than Z8 and Z10 during pre-computation.

Dominant layer was landuse_gen0. It was using subpixel rendering for landuse, which is useful at very low zoom but seems to be safely discardable at Z9.

Also add checking of way geometries against bboxes to ensure correct usage of geospatial indexes in db.

See as well
https://github.com/gravitystorm/openstreetmap-carto/pull/2874 and https://github.com/gravitystorm/openstreetmap-carto/pull/3458#issuecomment-430873795.

See https://github.com/cyclosm/cyclosm-cartocss-style/issues/644.


## Screenshots

### Before change

![2023-03-04-191940](https://user-images.githubusercontent.com/3856586/222923112-dd92b6c8-a719-4203-a8fc-93699483a365.png)


### After change

![2023-03-04-191943](https://user-images.githubusercontent.com/3856586/222923118-6833048d-4524-4075-9733-6f44e4a79189.png)



## SQL timings

### Before change

```
+-----------+----------------+-----------------------+-----------------+---------------------------+---------+
| Time (ms) | #lines fetched |         Layer         | #fields fetched | Size (text format, in kB) | #points |
+-----------+----------------+-----------------------+-----------------+---------------------------+---------+
|   155739  |     87807      |      landuse_gen0     |        6        |           93472           | 2724436 |
|   72884   |      241       |    protected-areas    |        7        |           21552           |  672438 |
|   21497   |      2886      |    landuse-overlay    |        6        |           75216           | 2337983 |
|   20718   |       64       |    military-overlay   |        6        |            386            |  11941  |
|   14091   |      856       |       water_gen0      |        5        |           19231           |  598569 |
|   13813   |     226936     |       roads_med       |        5        |           31984           |  715500 |
|   10909   |     23439      | bicycle_routes_labels |        9        |           110236          | 3383817 |
|    4262   |     29195      |      waterway_low     |        4        |           10035           |  280558 |
|    4198   |      659       |     admin-low-zoom    |        4        |           22069           |  688972 |
|    3338   |       23       |      state-names      |        6        |           32326           | 1008810 |
|    3125   |       9        |     country-names     |        5        |           20773           |  648968 |
|    1170   |     11270      |  bicycle_routes_gen2  |        6        |            1641           |  35559  |
|    264    |      1470      |   placenames-medium   |        7        |            109            |   1470  |
|     86    |      400       |      ferry-routes     |        4        |            168            |   4846  |
|     33    |       4        |     capital-names     |        6        |             0             |    4    |
+-----------+----------------+-----------------------+-----------------+---------------------------+---------+
```


### After change

```
+-----------+----------------+-----------------------+-----------------+---------------------------+---------+
| Time (ms) | #lines fetched |         Layer         | #fields fetched | Size (text format, in kB) | #points |
+-----------+----------------+-----------------------+-----------------+---------------------------+---------+
|   22350   |      9067      |      landuse_gen1     |        6        |           203399          | 6321176 |
|   14217   |      856       |       water_gen0      |        5        |           19231           |  598569 |
|   13356   |     226936     |       roads_med       |        5        |           31984           |  715500 |
|   11347   |     23479      | bicycle_routes_labels |        9        |           110715          | 3398663 |
|    8064   |      2886      |    landuse-overlay    |        6        |           75216           | 2337983 |
|    4483   |     29195      |      waterway_low     |        4        |           10035           |  280558 |
|    4434   |      659       |     admin-low-zoom    |        4        |           22069           |  688972 |
|    3300   |       23       |      state-names      |        6        |           32326           | 1008810 |
|    2087   |       9        |     country-names     |        5        |           20773           |  648968 |
|    2034   |      241       |    protected-areas    |        7        |           21552           |  672438 |
|    1341   |     11270      |  bicycle_routes_gen2  |        6        |            1641           |  35559  |
|    428    |       64       |    military-overlay   |        6        |            386            |  11941  |
|    262    |      1470      |   placenames-medium   |        7        |            109            |   1470  |
|     29    |      400       |      ferry-routes     |        4        |            168            |   4846  |
|     16    |       4        |     capital-names     |        6        |             0             |    4    |
+-----------+----------------+-----------------------+-----------------+---------------------------+---------+
```