### PR TITLE
Unnecessary ending dot on node_network labels

### DIFF
--- a/project.mml
+++ b/project.mml
@@ -995,11 +995,10 @@ Layer:
       (
         SELECT
           way,
-          CONCAT(SUBSTR(
+          RIGHT(
             COALESCE(tags->'icn_ref', tags->'ncn_ref', tags->'rcn_ref', tags->'lcn_ref'),
-            0,
             4
-          ), '.') AS ref,
+          ) AS ref,
           CASE
             WHEN (tags->'icn_ref') IS NOT NULL THEN 'icn'
             WHEN (tags->'ncn_ref') IS NOT NULL THEN 'ncn'


### PR DESCRIPTION
As per
https://github.com/cyclosm/cyclosm-cartocss-style/issues/660#issuecomment-1773789357:
* Remove the final dot in the truncation of cycle junction node names.
* Keep the final characters instead of the leading ones.

Fix #660