### PR TITLE
show com towers at level 11 for deciding route and where to rest

### DIFF
--- a/amenities.mss
+++ b/amenities.mss
@@ -496,6 +496,18 @@
     marker-clip: false;
   }
 
+  [feature = 'man_made_communications_tower'][zoom >= 11] {
+    marker-file: url('symbols/openstreetmap-carto/man_made/mast_communications.svg');
+    text-name: "[name]";
+    text-size: @standard-font-size;
+    text-face-name: @standard-font;
+    text-wrap-width: @standard-wrap-width;
+    text-line-spacing: @standard-line-spacing-size;
+    # text-fill: darken(@man-made-icon, 20%);
+    # text-halo-radius: @standard-halo-radius;
+    # text-halo-fill: @standard-halo-fill;
+  }
+
   [feature = 'historic_memorial'][memorial = null][zoom >= 17],
   [feature = 'historic_memorial'][memorial != null][memorial != 'blue_plaque'][memorial != 'bust'][memorial != 'plaque'][memorial != 'stele'][memorial != 'stone'][zoom >= 17],
   [feature = 'historic_memorial'][memorial = 'statue'][zoom >= 17],


### PR DESCRIPTION
I need to see com towers and food shops to criss cross my route and
decide where to stay. I work at night and need a good reception . I use
level 11 for over view I need cell towers and food shops at 11. burger
shops are pointless I need a week's food

 # keep the name

 the name is not pointless I am adding the operators in the name on
 expedition around Finland. DNA is absent from some towers. so don't
 remove the name it will be more useful to see if you have a signal from
 the tower

 # as of yet untested

I am still working on testing this I will be able to host my own map
eventually currently I have the standard carto in my own server but
kosmtik mapnik will require more mork to find a working combination .
kosmtik fail and there is no mapnik-config file in the repo

~~~
apt-file find mapnik-config
nothing
~~~
