### PR TITLE
ci: upgrade Node.js to 20.x and fix Python/pip compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 20.x
       - name: Install Kosmtik
         run: |
           git clone https://github.com/kosmtik/kosmtik
@@ -23,6 +23,6 @@ jobs:
           ./kosmtik/node_modules/.bin/carto -b project.mml -f mapnik.xml 2>&1 | grep -v Warning:
       - name: Inspect Mapnik XML
         run: |
-          pip install prettytable
+          pip install --break-system-packages prettytable
           ./kosmtik/node_modules/.bin/carto project.mml -f mapnik.xml
-          python scripts/inspect_mapnik_xml.py mapnik.xml
+          python3 scripts/inspect_mapnik_xml.py mapnik.xml


### PR DESCRIPTION
Node 12 is incompatible with @mapnik/mapnik@4.7.8 (requires ^18||^20||>=21), and node-gyp 5.x bundled with npm@6 uses Python's removed 'rU' file mode. Upgrading to Node 20 resolves both issues. Also update action versions to current stable releases and fix pip/python invocations for Ubuntu 24.04.

https://claude.ai/code/session_01Y2G6frKfFaTtYT9LRQbtMc