### PR TITLE
Modernize Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,13 @@ scripts/test/*.txt
 tmp/
 .kosmtik-config.yml
 .env
+.idea/
+.DS_Store
+*.osm.pbf
+# Pre-rendered static tiles (docker/static pipeline)
+tiles/
+mbtiles/
+*.mbtiles
+docker/static/mapnik.xml
+# Keep the static-tile pipeline's localconfig (overrides localconfig*.json above)
+!docker/static/localconfig.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,29 @@
-FROM ubuntu:bionic
+FROM debian:trixie-slim
 
-# Style dependencies
+# Style + kosmtik dependencies. git builds kosmtik from sources below.
+# Mapnik itself comes from @mapnik/mapnik's prebuilt core package (pulled by
+# npm), so no system Mapnik / build toolchain is required.
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    ca-certificates curl gnupg postgresql-client python fonts-hanazono \
-    fonts-noto-cjk fonts-noto-hinted fonts-noto-unhinted mapnik-utils \
-    nodejs npm ttf-unifont unzip && rm -rf /var/lib/apt/lists/*
+    ca-certificates curl git python3 postgresql-client sqlite3 nodejs npm \
+    unzip fonts-hanazono fonts-noto-cjk fonts-noto-core fonts-noto-extra \
+    fonts-unifont && rm -rf /var/lib/apt/lists/*
 
-# Kosmtik with plugins, forcing prefix to /usr because bionic sets
-# npm prefix to /usr/local, which breaks the install
-RUN npm set prefix /usr && npm install -g kosmtik
+# @mapnik/mapnik ships a prebuilt core, but its preinstall script aborts under
+# `set -e` when `mapnik-config -v` is missing (Mapnik 4 dropped mapnik-config).
+# A tiny shim answering -v lets preinstall pass; the prebuilt core is then used
+# as-is with no compilation.
+RUN printf '#!/bin/sh\ncase "$1" in -v|--version) echo 4.2.2;; *) echo;; esac\n' \
+    > /usr/local/bin/mapnik-config && chmod +x /usr/local/bin/mapnik-config
 
-WORKDIR /usr/lib/node_modules/kosmtik/
+# Build kosmtik from sources (latest master)
+# @mapnik/core hoisted as a sibling so node-gyp-build picks up the prebuilt
+# binary instead of trying to compile; a wrapper exposes the kosmtik CLI.
+RUN git clone --depth 1 https://github.com/kosmtik/kosmtik.git /opt/kosmtik \
+    && (cd /opt/kosmtik && npm install) \
+    && printf '#!/bin/sh\nexec node /opt/kosmtik/index.js "$@"\n' \
+       > /usr/local/bin/kosmtik && chmod +x /usr/local/bin/kosmtik
+
+WORKDIR /opt/kosmtik/
 RUN kosmtik plugins --install kosmtik-overpass-layer \
                     --install kosmtik-fetch-remote \
                     --install kosmtik-overlay \

--- a/Dockerfile.db
+++ b/Dockerfile.db
@@ -1,3 +1,3 @@
-FROM mdillon/postgis
+FROM imresamu/postgis:17-3.5-bookworm
 
 ADD ./scripts/tune-postgis.sh /docker-entrypoint-initdb.d

--- a/Dockerfile.import
+++ b/Dockerfile.import
@@ -1,14 +1,4 @@
-FROM ubuntu:bionic
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    ca-certificates curl gnupg && rm -rf /var/lib/apt/lists/*
-
-RUN echo 'deb http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main\n\
-deb-src http://ppa.launchpad.net/osmadmins/ppa/ubuntu bionic main' > \
-    /etc/apt/sources.list.d/osmadmins-ppa.list
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-    --recv A438A16C88C6BE41CB1616B8D57F48750AC4F2CB
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     osm2pgsql postgresql-client && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -1,0 +1,22 @@
+# Podman overlay for rootless deployment (Fedora/RHEL).
+#
+#   podman-compose -f docker-compose.yml -f docker-compose.podman.yml ...
+#
+# Why this is needed: the `kosmtik` and `render` containers run as USER 1000 in
+# the image, but must WRITE to the bind-mounted repo (tmp/, data/, mbtiles/).
+# Under rootless Podman your host user maps to container UID 0, so we run these
+# two services as root inside the container — that maps back to your host user
+# and can write host-owned files.
+#
+# We use `user: 0` rather than `userns_mode: keep-id` because podman-compose puts
+# services in a shared pod by default, and Podman rejects a per-container
+# --userns together with --pod ("--userns and --pod cannot be set together").
+#
+# SELinux: docker-compose.yml already carries `:z` mount labels. They are no-ops
+# when SELinux is permissive/disabled (and on Docker/macOS), and do the right
+# relabeling if SELinux is ever set to enforcing — so nothing extra is required.
+services:
+  kosmtik:
+    user: "0:0"
+  render:
+    user: "0:0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   kosmtik:
     image: kosmtik:v1
@@ -6,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - .:/cyclosm
+      - .:/cyclosm:z
     depends_on:
       - db
     ports:
@@ -14,23 +13,30 @@ services:
     environment:
       - PGHOST=db
       - PGUSER=postgres
+
   db:
     image: db:v1
     build:
       context: .
       dockerfile: Dockerfile.db
+    # Postgres puts parallel-query shared memory in /dev/shm; Docker's 64MB
+    # default overflows on big tile queries ("No space left on device").
+    shm_size: "1gb"
     ports:
       - "127.0.0.1:5432:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
     environment:
       - PG_WORK_MEM
       - PG_MAINTENANCE_WORK_MEM
+      - POSTGRES_HOST_AUTH_METHOD=trust
   import:
     image: import:v1
     build:
       context: .
       dockerfile: Dockerfile.import
     volumes:
-      - .:/cyclosm
+      - .:/cyclosm:z
     depends_on:
       - db
     environment:
@@ -41,3 +47,65 @@ services:
       - OSM2PGSQL_CACHE
       - OSM2PGSQL_NUMPROC
       - OSM2PGSQL_DATAFILE
+
+  # Static tile pipeline (opt-in: `docker compose --profile static ...`).
+  # Compiles project.mml -> mapnik.xml then pre-renders tiles
+  render:
+    image: kosmtik:v1
+    profiles: ["static"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - db
+    volumes:
+      - .:/cyclosm:z
+    working_dir: /cyclosm
+    environment:
+      - HOME=/tmp
+      - PGHOST=db
+      - PGUSER=postgres
+      - PGDATABASE=osm
+      - NODE_PATH=/opt/kosmtik/node_modules
+      # Persisted on the bind mount, so it survives `run --rm` and is reused
+      # (and auto-recompiled when project.mml/*.mss/localconfig change).
+      - MAPNIK_XML=/cyclosm/docker/static/mapnik.xml
+      - MAPNIK_BASE=/cyclosm
+      # Output: "mbtiles" (single SQLite file, served by tileserver) or "dir".
+      - OUTPUT=mbtiles
+      - TILE_DIR=/cyclosm/tiles
+      - MBTILES=/cyclosm/mbtiles/cyclosm.mbtiles
+      # Area to render:
+      #   BBOX=auto -> extent of the imported data; or a "W,S,E,N" lon/lat box.
+      - BBOX=auto
+      - MIN_ZOOM=0
+      - MAX_ZOOM=10
+      # Optional clip: leave empty to render the BBOX. Set to an OSM admin
+      # boundary name (name or name:en) to render only tiles intersecting it,
+      # e.g. CLIP=Polska / CLIP=France. CLIP_ADMIN_LEVEL: 2=country, 4=region.
+      - CLIP=
+      - CLIP_ADMIN_LEVEL=2
+      # Parallel renders. The entrypoint sets UV_THREADPOOL_SIZE to match, so
+      # this actually scales with CPU. Default 4 is conservative for broad
+      # compatibility; raise toward the core count (RAM permitting, ~0.7-1 GB
+      # per worker) on bigger hosts. See docs/STATIC_TILES.md.
+      - CONCURRENCY=4
+      - SKIP_EXPORT=0
+    command: sh docker/static/render-entrypoint.sh
+
+  # Serves the rendered MBTiles over XYZ + TileJSON, with a built-in Leaflet
+  # preview, on :18889. Each ./mbtiles/<name>.mbtiles becomes a service:
+  #   tiles:   http://127.0.0.1:18889/services/<name>/tiles/{z}/{x}/{y}.png
+  #   preview: http://127.0.0.1:18889/services/<name>/map
+  #   list:    http://127.0.0.1:18889/services
+  tileserver:
+    image: ghcr.io/consbio/mbtileserver:latest
+    profiles: ["static"]
+    ports:
+      - "127.0.0.1:18889:8080"
+    volumes:
+      - ./mbtiles:/data:ro,z
+    command: ["--dir", "/data", "--port", "8080", "--enable-fs-watch"]
+
+volumes:
+  db-data:

--- a/docker/static/clip-cover.sql
+++ b/docker/static/clip-cover.sql
@@ -1,0 +1,36 @@
+-- Compute the slippy-tile cover of an administrative boundary by descending the
+-- tile quadtree from z0 and keeping only tiles whose Web-Mercator envelope
+-- intersects the (simplified, slightly buffered) boundary polygon.
+--
+-- psql variables:
+--   :clipname  OSM boundary name; matched against the `name` or `name:en` tag
+--              (e.g. Polska / Poland, Deutschland / Germany, France).
+--   :level     admin_level of the boundary (2 = country, 4 = state/region, ...).
+--   :minz :maxz  zoom range, inclusive.
+-- Example:
+--   psql -d osm -tA -F' ' -v minz=0 -v maxz=14 -v level=2 -v clipname=Polska \
+--        -f docker/static/clip-cover.sql -o cover.txt
+-- Output: one "z x y" (XYZ/Google scheme) line per tile, z in [minz, maxz].
+WITH RECURSIVE clip AS (
+  -- One-time: pick the boundary, simplify (cheaper intersection) and buffer
+  -- outward ~1km so border tiles are never dropped (over-inclusion is harmless).
+  SELECT ST_Buffer(ST_Simplify(way, 1000), 1000) AS geom
+  FROM planet_osm_polygon
+  WHERE boundary = 'administrative'
+    AND admin_level = :'level'
+    AND (name = :'clipname' OR tags->'name:en' = :'clipname')
+  ORDER BY ST_Area(way) DESC
+  LIMIT 1
+),
+q(z, x, y) AS (
+  SELECT 0, 0, 0
+  UNION ALL
+  SELECT c.z + 1, c.x * 2 + dx, c.y * 2 + dy
+  FROM q c
+       CROSS JOIN clip
+       CROSS JOIN (VALUES (0), (1)) AS gx(dx)
+       CROSS JOIN (VALUES (0), (1)) AS gy(dy)
+  WHERE c.z < :maxz
+    AND ST_Intersects(clip.geom, ST_TileEnvelope(c.z + 1, c.x * 2 + dx, c.y * 2 + dy))
+)
+SELECT z, x, y FROM q WHERE z >= :minz;

--- a/docker/static/localconfig.json
+++ b/docker/static/localconfig.json
@@ -1,0 +1,42 @@
+[
+  {
+    "where": "Layer",
+    "if": { "Datasource.type": "postgis" },
+    "then": { "Datasource.host": "db", "Datasource.user": "postgres" }
+  },
+  {
+    "where": "Layer",
+    "if": { "id": "land-low" },
+    "then": { "Datasource.file": "/cyclosm/data/land-low/land-low.shp" }
+  },
+  {
+    "where": "Layer",
+    "if": { "id": "land-high" },
+    "then": { "Datasource.file": "/cyclosm/data/land-high/land-high.shp" }
+  },
+  {
+    "where": "Layer",
+    "if": { "id": "contours100" },
+    "then": { "properties.status": "off" }
+  },
+  {
+    "where": "Layer",
+    "if": { "id": "contours50" },
+    "then": { "properties.status": "off" }
+  },
+  {
+    "where": "Layer",
+    "if": { "id": "contours20" },
+    "then": { "properties.status": "off" }
+  },
+  {
+    "where": "Layer",
+    "if": { "id": "contours10" },
+    "then": { "properties.status": "off" }
+  },
+  {
+    "where": "Layer",
+    "if": { "id": "hillshade" },
+    "then": { "properties.status": "off" }
+  }
+]

--- a/docker/static/render-entrypoint.sh
+++ b/docker/static/render-entrypoint.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Pipeline for the `render` service: compile project.mml -> mapnik.xml, then
+# batch-render static tiles (to a directory or MBTiles), optionally clipped to an
+# administrative boundary. Run from /cyclosm (working_dir in docker-compose).
+#
+# What gets rendered:
+#   CLIP unset/empty/"none"  -> the BBOX rectangle.
+#       BBOX="auto" (default) -> the extent of the imported data (queried from PostGIS).
+#       BBOX="W,S,E,N"        -> that lon/lat rectangle.
+#   CLIP="<name>"            -> only tiles intersecting the admin boundary whose
+#       name (or name:en) is <name>, at admin_level CLIP_ADMIN_LEVEL (default 2).
+set -e
+
+export HOME=/tmp                       # kosmtik export wants a writable HOME
+# Default to a path on the bind-mounted repo so the compiled XML survives across
+# `run --rm` containers (an ephemeral /tmp would force a re-export every run).
+MAPNIK_XML="${MAPNIK_XML:-/cyclosm/docker/static/mapnik.xml}"
+
+# Compile unless a cached XML exists and is newer than the style sources.
+# SKIP_EXPORT=1 forces reuse even if the sources changed.
+need_export=1
+if [ -f "$MAPNIK_XML" ]; then
+  if [ "${SKIP_EXPORT:-0}" = "1" ]; then
+    need_export=0
+  elif [ -z "$(find project.mml *.mss docker/static/localconfig.json -newer "$MAPNIK_XML" 2>/dev/null)" ]; then
+    need_export=0   # cached XML is up to date with project.mml / *.mss / localconfig
+  fi
+fi
+if [ "$need_export" = "1" ]; then
+  echo "[render] Compiling project.mml -> $MAPNIK_XML (this can take several minutes)..."
+  mkdir -p "$(dirname "$MAPNIK_XML")"
+  kosmtik export project.mml \
+    --localconfig docker/static/localconfig.json \
+    --output "$MAPNIK_XML"
+else
+  echo "[render] Reusing cached $MAPNIK_XML (up to date)"
+fi
+export MAPNIK_XML
+
+# Preflight: the land-polygon shapefiles the localconfig points at must exist,
+# else the render fails later with a cryptic Mapnik shapefile error.
+for lp in land-low land-high; do
+  if [ ! -f "data/$lp/$lp.shp" ]; then
+    echo "[render] ERROR: missing data/$lp/$lp.shp — run 'sh scripts/get-land-polygons.sh' first." >&2
+    exit 1
+  fi
+done
+
+CLIP="${CLIP:-}"
+if [ -n "$CLIP" ] && [ "$CLIP" != "none" ]; then
+  # Clip to an administrative boundary: render only intersecting tiles.
+  COVER="${TILE_LIST:-/tmp/cover.txt}"
+  if [ "${SKIP_COVER:-0}" != "1" ] || [ ! -s "$COVER" ]; then
+    echo "[render] Computing tile cover for '$CLIP' (admin_level ${CLIP_ADMIN_LEVEL:-2}) z${MIN_ZOOM:-0}-${MAX_ZOOM:-10} ..."
+    # ON_ERROR_STOP=1 so a SQL error makes psql exit non-zero (caught by `set -e`)
+    # instead of silently leaving a partial/empty cover.
+    psql -d "${PGDATABASE:-osm}" -q -tA -F' ' -v ON_ERROR_STOP=1 \
+      -v minz="${MIN_ZOOM:-0}" -v maxz="${MAX_ZOOM:-10}" \
+      -v level="${CLIP_ADMIN_LEVEL:-2}" -v clipname="$CLIP" \
+      -f docker/static/clip-cover.sql -o "$COVER"
+    if [ ! -s "$COVER" ]; then
+      echo "[render] ERROR: no boundary named '$CLIP' at admin_level ${CLIP_ADMIN_LEVEL:-2} in the database." >&2
+      exit 1
+    fi
+    echo "[render] cover: $(wc -l < "$COVER") tiles"
+  else
+    echo "[render] Reusing existing cover $COVER (SKIP_COVER=1)"
+  fi
+  export TILE_LIST="$COVER"
+else
+  # No clip: render the BBOX rectangle. "auto" = extent of the imported data.
+  if [ "${BBOX:-auto}" = "auto" ]; then
+    BBOX="$(psql -d "${PGDATABASE:-osm}" -tA -v ON_ERROR_STOP=1 -c \
+      "SELECT ST_XMin(g)||','||ST_YMin(g)||','||ST_XMax(g)||','||ST_YMax(g) \
+       FROM (SELECT ST_Extent(ST_Transform(way,4326)) g FROM planet_osm_point) s;")"
+    # Validate: four numeric fields and a non-degenerate box (W<E, S<N). An empty
+    # DB yields NULL (blank), a single point yields a zero-area box — reject both.
+    IFS=, read -r w s e n <<EOF
+$BBOX
+EOF
+    if [ -z "$n" ] || ! awk -v w="$w" -v s="$s" -v e="$e" -v n="$n" \
+         'BEGIN { exit (w+0 < e+0 && s+0 < n+0) ? 0 : 1 }'; then
+      echo "[render] ERROR: could not determine a valid data extent (got '$BBOX'); is the DB imported?" >&2
+      exit 1
+    fi
+    export BBOX
+    echo "[render] auto BBOX (imported data extent) = $BBOX"
+  fi
+fi
+
+# node-mapnik renders on libuv's thread pool, whose default size is 4 — so
+# CONCURRENCY > 4 has no effect unless the pool is enlarged to match. Must be set
+# before node starts. An explicit UV_THREADPOOL_SIZE wins; otherwise track CONCURRENCY.
+export UV_THREADPOOL_SIZE="${UV_THREADPOOL_SIZE:-${CONCURRENCY:-4}}"
+
+echo "[render] Rendering tiles (output=${OUTPUT:-mbtiles}, concurrency=${CONCURRENCY:-4}, UV_THREADPOOL_SIZE=$UV_THREADPOOL_SIZE)..."
+exec node /cyclosm/scripts/render-tiles.js

--- a/docs/DEPLOY_PODMAN.md
+++ b/docs/DEPLOY_PODMAN.md
@@ -1,0 +1,117 @@
+Deploying the CyclOSM tile stack with Podman (rootless, Fedora/RHEL/Oracle Linux, arm64)
+========================================================================================
+
+This runs the **full pipeline** — PostGIS + import + render + MBTiles server —
+on a rootless Podman host, reusing `docker-compose.yml` plus the Podman overlay
+`docker-compose.podman.yml`.
+
+Everything is arm64-native (Debian base images, `imresamu/postgis`,
+`ghcr.io/consbio/mbtileserver`, and `@mapnik/mapnik`'s prebuilt linux-arm64 core),
+so nothing needs rebuilding for the architecture.
+
+## 0. Prerequisites
+
+```sh
+sudo dnf install -y podman podman-compose git curl unzip
+```
+
+- **Rootless mapping**: ensure your user has subuid/subgid ranges (usually preset
+  on Fedora; check `grep "$USER" /etc/subuid /etc/subgid`). If empty:
+  `sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$USER"`
+  then log out/in.
+- **Registries**: Fedora's default `unqualified-search-registries` includes
+  `docker.io`, so the unqualified image names (`debian`, `imresamu/postgis`)
+  resolve. If yours doesn't, add `docker.io` to
+  `/etc/containers/registries.conf` or fully-qualify the names.
+- **SELinux**: the compose file uses `:z` bind-mount labels, which work whether
+  SELinux is permissive or enforcing (and are no-ops when disabled).
+
+`podman-compose` is used below; `podman compose` (the v2 provider) also works if
+installed. Profiles require podman-compose ≥ 1.0.6.
+
+A convenience alias for the rest of this doc:
+
+```sh
+alias dc='podman-compose -f docker-compose.yml -f docker-compose.podman.yml'
+```
+
+## 1. Get the code + data
+
+```sh
+git clone https://github.com/thof/cyclosm-cartocss-style.git
+cd cyclosm-cartocss-style
+curl -L -o data.osm.pbf https://download.geofabrik.de/europe/poland-latest.osm.pbf # the region to render
+sh scripts/get-land-polygons.sh                                                    # land shapefiles -> data/
+```
+
+`get-land-polygons.sh` downloads the coastline/land shapefiles the style needs
+into `data/land-low/` and `data/land-high/` (≈0.6 GB download, ≈1.3 GB extracted).
+
+## 2. Build the local images
+
+```sh
+dc build            # builds kosmtik:v1 and import:v1 via buildah
+```
+
+## 3. Import the OSM data (one-time; repeat only when data.osm.pbf changes)
+
+```sh
+dc up -d db
+dc run --rm import
+```
+
+Import tuning lives in `.env` (created on first import). For a big extract raise
+`OSM2PGSQL_CACHE` / `OSM2PGSQL_NUMPROC` and `PG_MAINTENANCE_WORK_MEM` to match the
+box, then re-run `dc run --rm import` (it re-imports from scratch — see DOCKER.md).
+The DB persists in the `db-data` named volume; re-import only on data updates.
+
+## 4. Render tiles to MBTiles
+
+```sh
+# Default: the extent of the imported data (BBOX=auto), z0-10:
+dc --profile static run --rm render
+
+# Or clip to a country/region boundary (skips sea/no-data), at higher zoom.
+# CLIP is an OSM admin boundary name (name or name:en); CLIP_ADMIN_LEVEL=2 is a
+# country (4 = state/region). Examples:
+dc --profile static run --rm -e CLIP=Polska -e MAX_ZOOM=12 render
+dc --profile static run --rm -e CLIP=France -e MAX_ZOOM=12 render
+```
+
+Output goes to `mbtiles/cyclosm.mbtiles`. Knobs (`CLIP`, `MAX_ZOOM`, `BBOX`,
+`CONCURRENCY`, `OUTPUT`, `SKIP_EXPORT`, `SKIP_COVER`) are env vars on the `render`
+service — override with `-e`. The first run compiles `mapnik.xml` (a few minutes,
+CPU-bound) to `docker/static/mapnik.xml`; later runs reuse it automatically and
+only recompile when `project.mml`/`*.mss`/`localconfig.json` change (`SKIP_EXPORT=1`
+forces reuse regardless).
+
+## 5. Serve
+
+```sh
+dc --profile static up -d tileserver
+```
+
+- Preview map:  `http://<host>:18889/services/cyclosm/map`
+- XYZ tiles:    `http://<host>:18889/services/cyclosm/tiles/{z}/{x}/{y}.png`
+- Service list: `http://<host>:18889/services`
+
+The server has `--enable-fs-watch`, so re-rendering `mbtiles/cyclosm.mbtiles`
+hot-reloads without a restart.
+
+## Notes
+
+- **Remote access**: ports bind to `127.0.0.1` by default. To expose the tile
+  server on the network, change the `tileserver` port mapping to `18889:8080`
+  (drop the `127.0.0.1:`) or, better, put a TLS reverse proxy (Caddy/nginx) in
+  front of it. The DB/kosmtik ports should stay localhost-only.
+- **Start on boot**: `podman-compose` doesn't manage boot. To keep the server
+  running across reboots, either enable lingering (`loginctl enable-linger
+  "$USER"`) and a user unit, or generate Quadlet units for the tileserver.
+- **Bind-mount writes (rootless)**: `docker-compose.podman.yml` runs the
+  `kosmtik`/`render` containers as `user: 0`, which maps to your host user under
+  rootless Podman so they can write the bind-mounted repo. (`db` uses a named
+  volume and `import` already runs as root, so neither needs it.) If PostGIS init
+  ever complains about volume ownership, remove the volume
+  (`dc down && podman volume rm cyclosm-cartocss-style_db-data`) and retry.
+- **Serve-only alternative**: if the box only needs to serve, render the
+  `.mbtiles` elsewhere, copy it into `mbtiles/` here, and run just step 5.

--- a/docs/STATIC_TILES.md
+++ b/docs/STATIC_TILES.md
@@ -1,0 +1,93 @@
+Pre-rendered static tiles with Docker (node-mapnik + MBTiles)
+=============================================================
+
+A self-contained pipeline that compiles the style, pre-renders raster tiles for
+an area/zoom range, and serves them — all via `docker compose`. It reuses the
+project's existing `kosmtik` image (which already ships a working Mapnik), so it
+needs no system Mapnik or Tirex. For the classic Tirex-based recipe see
+[STATIC_TILE_SERVER.md](STATIC_TILE_SERVER.md); for Podman/server deployment see
+[DEPLOY_PODMAN.md](DEPLOY_PODMAN.md).
+
+## Prerequisites
+
+1. An imported PostGIS database — see [DOCKER.md](DOCKER.md) (`docker compose up
+   import`). The render reads vector data from it.
+2. Land-polygon shapefiles in `data/` (the style's low-zoom coastline). In the
+   dev workflow `kosmtik` fetches these automatically; on a fresh checkout run:
+   ```sh
+   sh scripts/get-land-polygons.sh
+   ```
+
+## Render and serve
+
+```sh
+# Render (default: the extent of the imported data, z0-10, to an MBTiles file):
+docker compose --profile static run --rm render
+
+# Serve it (mbtileserver, with a built-in Leaflet preview) on :18889:
+docker compose --profile static up -d tileserver
+```
+
+- Preview:  `http://localhost:18889/services/cyclosm/map`
+- XYZ:      `http://localhost:18889/services/cyclosm/tiles/{z}/{x}/{y}.png`
+- TileJSON: `http://localhost:18889/services/cyclosm`
+
+Re-running `render` hot-reloads the server (it watches the file).
+
+## Options (env on the `render` service; override with `-e`)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `BBOX` | `auto` | `auto` = extent of imported data; or `"W,S,E,N"` lon/lat |
+| `MIN_ZOOM` / `MAX_ZOOM` | `0` / `10` | zoom range (inclusive) |
+| `CLIP` | *(empty)* | OSM admin boundary name (`name`/`name:en`) to clip to; empty = render `BBOX`. Clipping skips sea/no-data tiles |
+| `CLIP_ADMIN_LEVEL` | `2` | admin level of `CLIP` (2 = country, 4 = state/region) |
+| `OUTPUT` | `mbtiles` | `mbtiles` (one file) or `dir` (loose `{z}/{x}/{y}.png`) |
+| `MBTILES` / `TILE_DIR` | `mbtiles/cyclosm.mbtiles` / `tiles` | output location |
+| `CONCURRENCY` | `4` | parallel renders (the entrypoint sets `UV_THREADPOOL_SIZE` to match); raise toward the core count |
+| `SKIP_EXPORT` | `0` | `mapnik.xml` is cached + reused automatically (recompiled when the style changes); `1` forces reuse even when sources changed |
+
+Examples:
+
+```sh
+# Clip to a country at higher zoom (much smaller than the bounding rectangle):
+docker compose --profile static run --rm -e CLIP=France -e MAX_ZOOM=12 render
+
+# Explicit bounding box, loose PNG output:
+docker compose --profile static run --rm \
+  -e BBOX=2.0,48.6,2.7,49.0 -e MAX_ZOOM=15 -e OUTPUT=dir render
+```
+
+## Tuning concurrency
+
+Rendering is CPU-bound, but two limits decide the sweet spot:
+
+- **libuv thread pool.** node-mapnik renders on libuv's thread pool, whose
+  default size is **4**. The render entrypoint sets `UV_THREADPOOL_SIZE` to equal
+  `CONCURRENCY` so raising `CONCURRENCY` actually adds parallelism — without that,
+  `CONCURRENCY > 4` does nothing (or is slightly slower).
+- **RAM, not cores, is usually the ceiling.** Each worker loads the style + the
+  land-polygon index + a DB connection (~0.7-1 GB). Too many workers OOM the host.
+
+To find the optimum on your hardware, sweep a fixed sample and watch tiles/s and
+memory (`docker stats` / `podman stats`); pick the plateau before RAM runs out:
+
+```sh
+for c in 4 8 12; do
+  rm -rf /tmp/bench
+  docker compose --profile static run --rm \
+    -e SKIP_EXPORT=1 -e OUTPUT=dir -e TILE_DIR=/tmp/bench \
+    -e BBOX=20.85,52.05,21.25,52.45 -e MIN_ZOOM=14 -e MAX_ZOOM=14 \
+    -e CONCURRENCY=$c render
+done
+```
+
+When the DB shares the box, leave a couple of cores for PostgreSQL. As a starting
+point use `CONCURRENCY ≈ min(cores, usable_RAM_GB)`. (Measured on a 12-core / 8 GB
+host with the DB co-resident: throughput peaked at `CONCURRENCY=8`; `12` OOM'd.)
+
+## Sizing
+
+Tile count (and time and storage) roughly **quadruples per zoom level**. The full
+extent of a large import past ~z12 is millions of tiles — clip to the area you
+actually need, and prefer `OUTPUT=mbtiles` (one file) over millions of PNGs.

--- a/docs/STATIC_TILE_SERVER.md
+++ b/docs/STATIC_TILE_SERVER.md
@@ -3,6 +3,10 @@ Set up a demo tile server serving static (pre-generated) tiles
 
 This is a complement to the [INSTALL.md](INSTALL.md) documentation.
 
+> For a self-contained, Docker-based alternative (no system Mapnik or Tirex
+> required — compiles the style, pre-renders tiles, and serves them via
+> `docker compose`), see [STATIC_TILES.md](STATIC_TILES.md).
+
 ### Requirements
 
 The following assumes you are using an Ubuntu 18.04 LTS distribution. If you

--- a/scripts/get-land-polygons.sh
+++ b/scripts/get-land-polygons.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Fetch the OSM land-polygon shapefiles that the static-tile pipeline's
+# localconfig (docker/static/localconfig.json) expects at:
+#   data/land-low/land-low.shp    (zoom 0-9, simplified)
+#   data/land-high/land-high.shp  (zoom 10+, full)
+#
+# On the dev machine these are normally fetched by kosmtik's fetch-remote plugin;
+# on a fresh server run this once before rendering. Needs curl + unzip.
+# Safe to re-run: files already present are skipped.
+set -e
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+fetch() {
+  name="$1"; url="$2"
+  if [ -f "data/$name/$name.shp" ]; then
+    echo "[land] $name already present — skipping"
+    return
+  fi
+  echo "[land] downloading $name from $url ..."
+  mkdir -p "data/$name"
+  tmp="$(mktemp -d)"
+  curl -fL -o "$tmp/d.zip" "$url"
+  unzip -j -o "$tmp/d.zip" -d "$tmp" >/dev/null
+  # Pick the extracted .shp without a masking pipeline (ls|head would hide a
+  # zero-match glob, since the pipeline's exit status is head's, not ls's).
+  set -- "$tmp"/*.shp
+  if [ ! -f "$1" ]; then
+    echo "[land] ERROR: no .shp found in $url archive" >&2
+    rm -rf "$tmp"; exit 1
+  fi
+  base="$(basename "$1" .shp)"
+  for ext in shp shx dbf prj cpg; do
+    [ -f "$tmp/$base.$ext" ] && mv "$tmp/$base.$ext" "data/$name/$name.$ext"
+  done
+  rm -rf "$tmp"
+  echo "[land] $name ready -> data/$name/$name.shp"
+}
+
+fetch land-low  "https://osmdata.openstreetmap.de/download/simplified-land-polygons-complete-3857.zip"
+fetch land-high "https://osmdata.openstreetmap.de/download/land-polygons-split-3857.zip"
+echo "[land] done."

--- a/scripts/render-tiles.js
+++ b/scripts/render-tiles.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/**
+ * Batch-render static raster tiles from a compiled Mapnik XML using node-mapnik.
+ *
+ * Runs inside the kosmtik:v1 Docker image (see the `render` service in
+ * docker-compose.yml), which provides the prebuilt `@mapnik/mapnik` core.
+ * Build the XML first, e.g.:
+ *   kosmtik export project.mml --localconfig docker/static/localconfig.json --output /tmp/mapnik.xml
+ *
+ * Tile set (what to render):
+ *   TILE_LIST    path to a "z x y" file (one tile per line) — e.g. a clip cover.
+ *                When set, BBOX/MIN_ZOOM/MAX_ZOOM are ignored.
+ *   BBOX         "W,S,E,N" lon/lat (default whole world; the render-entrypoint
+ *                normally resolves "auto" to the imported data extent and passes
+ *                a concrete box here)
+ *   MIN_ZOOM     inclusive                    (default 0)
+ *   MAX_ZOOM     inclusive                    (default 10)
+ *
+ * Output (where to write):
+ *   OUTPUT       "mbtiles" (default) | "dir"
+ *   TILE_DIR     dir mode root for {z}/{x}/{y}.png   (default /cyclosm/tiles)
+ *   MBTILES      mbtiles file path                   (default /cyclosm/mbtiles/cyclosm.mbtiles)
+ *
+ * Other:
+ *   MAPNIK_XML   compiled XML        (default /cyclosm/docker/static/mapnik.xml)
+ *   MAPNIK_BASE  base for rel paths  (default /cyclosm)
+ *   CONCURRENCY  parallel renders    (default = CPU count)
+ *
+ * NOTE: mapnik.Projection.forward() is broken in this Mapnik 4.2 build, so we
+ * compute Web-Mercator (EPSG:3857) meters directly rather than reprojecting.
+ * MBTiles stores rows in the TMS scheme (y flipped): row = 2^z - 1 - y.
+ */
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+var cp = require('child_process');
+var mapnik = require('@mapnik/mapnik');
+
+mapnik.register_default_input_plugins();
+mapnik.registerFonts('/usr/share/fonts', { recurse: true });
+
+var XML = process.env.MAPNIK_XML || '/cyclosm/docker/static/mapnik.xml';
+var BASE = process.env.MAPNIK_BASE || '/cyclosm';
+var OUTPUT = (process.env.OUTPUT || 'mbtiles').toLowerCase();
+var TILE_DIR = process.env.TILE_DIR || '/cyclosm/tiles';
+var MBTILES = process.env.MBTILES || '/cyclosm/mbtiles/cyclosm.mbtiles';
+var TILE_LIST = process.env.TILE_LIST || '';
+var MINZ = parseInt(process.env.MIN_ZOOM || '0', 10);
+var MAXZ = parseInt(process.env.MAX_ZOOM || '10', 10);
+var BBOX = (process.env.BBOX || '-180,-85.0511,180,85.0511').split(',').map(Number);
+var CONC = parseInt(process.env.CONCURRENCY || String(os.cpus().length), 10);
+var TILE = 256;
+
+// --- Web Mercator (spherical, EPSG:3857) helpers ---
+var R = 6378137, D2R = Math.PI / 180, MAX_LAT = 85.0511287798;
+function clampLat(lat) { return Math.max(-MAX_LAT, Math.min(MAX_LAT, lat)); }
+function lon2m(lon) { return lon * D2R * R; }
+function lat2m(lat) { return R * Math.log(Math.tan(Math.PI / 4 + clampLat(lat) * D2R / 2)); }
+function lon2tile(lon, z) { return Math.floor((lon + 180) / 360 * Math.pow(2, z)); }
+function lat2tile(lat, z) {
+  var r = clampLat(lat) * D2R;
+  return Math.floor((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2 * Math.pow(2, z));
+}
+function tile2lon(x, z) { return x / Math.pow(2, z) * 360 - 180; }
+function tile2lat(y, z) {
+  var n = Math.PI - 2 * Math.PI * y / Math.pow(2, z);
+  return 180 / Math.PI * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+}
+
+// --- Build the job list (from a tile-list file, or the bbox/zoom range) ---
+var jobs = [];
+if (TILE_LIST) {
+  var lines = fs.readFileSync(TILE_LIST, 'utf8').split('\n');
+  for (var li = 0; li < lines.length; li++) {
+    var p = lines[li].trim().split(/\s+/);
+    if (p.length < 3 || p[0] === '') continue;
+    jobs.push({ z: +p[0], x: +p[1], y: +p[2] });
+  }
+  console.log('[render] tile list ' + TILE_LIST + ': ' + jobs.length + ' tiles');
+} else {
+  for (var z = MINZ; z <= MAXZ; z++) {
+    var nz = Math.pow(2, z);
+    var xmin = Math.max(0, lon2tile(BBOX[0], z)), xmax = Math.min(nz - 1, lon2tile(BBOX[2], z));
+    var ymin = Math.max(0, lat2tile(BBOX[3], z)), ymax = Math.min(nz - 1, lat2tile(BBOX[1], z));
+    for (var x = xmin; x <= xmax; x++)
+      for (var y = ymin; y <= ymax; y++)
+        jobs.push({ z: z, x: x, y: y });
+  }
+  console.log('[render] bbox ' + BBOX.join(',') + ' zoom ' + MINZ + '-' + MAXZ + ': ' + jobs.length + ' tiles');
+}
+
+// Metadata zoom range + WGS84 bounds. Bounds are taken from the deepest zoom
+// only, whose small tiles tightly hug the region (low-zoom tiles each span a
+// huge area and would otherwise blow the bounds out to the whole world).
+var zMin = 99, zMax = 0;
+for (var jz = 0; jz < jobs.length; jz++) {
+  if (jobs[jz].z < zMin) zMin = jobs[jz].z;
+  if (jobs[jz].z > zMax) zMax = jobs[jz].z;
+}
+var bMinLon = 180, bMinLat = 90, bMaxLon = -180, bMaxLat = -90;
+for (var j = 0; j < jobs.length; j++) {
+  var t = jobs[j];
+  if (t.z !== zMax) continue;
+  bMinLon = Math.min(bMinLon, tile2lon(t.x, t.z));
+  bMaxLon = Math.max(bMaxLon, tile2lon(t.x + 1, t.z));
+  bMinLat = Math.min(bMinLat, tile2lat(t.y + 1, t.z));
+  bMaxLat = Math.max(bMaxLat, tile2lat(t.y, t.z));
+}
+
+// --- Output sink: dir (loose PNGs) or mbtiles (single SQLite file) ---
+function makeDirSink() {
+  return {
+    has: function (z, x, y) { return fs.existsSync(path.join(TILE_DIR, '' + z, '' + x, y + '.png')); },
+    write: function (z, x, y, buf, cb) {
+      var d = path.join(TILE_DIR, '' + z, '' + x);
+      fs.mkdir(d, { recursive: true }, function () { fs.writeFile(path.join(d, y + '.png'), buf, cb); });
+    },
+    finalize: function (cb) { cb(); }
+  };
+}
+
+function makeMbtilesSink() {
+  fs.mkdirSync(path.dirname(MBTILES), { recursive: true });
+  var seen = new Set();
+  if (fs.existsSync(MBTILES)) {
+    try {
+      var rows = cp.execFileSync('sqlite3', [MBTILES,
+        "SELECT zoom_level||'/'||tile_column||'/'||tile_row FROM tiles"],
+        { maxBuffer: 1 << 30 }).toString();
+      rows.split('\n').forEach(function (r) { if (r) seen.add(r); });
+      if (seen.size) console.log('[render] mbtiles has ' + seen.size + ' existing tiles (will skip)');
+    } catch (e) {
+      var msg = String((e && e.stderr) || (e && e.message) || e);
+      // A fresh file simply has no `tiles` table yet — nothing to resume.
+      // Any other failure (e.g. output exceeds maxBuffer on a huge mbtiles) must
+      // NOT be silent: warn so the operator knows resume is disabled this run.
+      if (!/no such table/.test(msg)) {
+        console.error('[render] WARNING: could not read existing tiles for resume (' +
+          msg.trim() + '); all tiles will be re-rendered (writes use INSERT OR REPLACE).');
+      }
+    }
+  }
+  var proc = cp.spawn('sqlite3', [MBTILES]);
+  var sqliteErr = null;
+  proc.stderr.on('data', function (d) { process.stderr.write('[sqlite3] ' + d); });
+  proc.on('error', function (e) { sqliteErr = sqliteErr || e; });
+  proc.stdin.on('error', function (e) { sqliteErr = sqliteErr || e; });
+  proc.on('exit', function (code) {
+    if (code && !sqliteErr) sqliteErr = new Error('sqlite3 exited with code ' + code);
+  });
+  // journal_mode=DELETE (on-disk rollback journal) + synchronous=NORMAL: an
+  // interrupted run rolls back the open transaction instead of corrupting the
+  // file (unlike journal_mode=MEMORY + synchronous=OFF). DELETE (not WAL) keeps
+  // the result a single plain file the tileserver can open from a read-only
+  // mount — a WAL db needs write access to its -wal sidecar even to read.
+  proc.stdin.write(
+    'PRAGMA journal_mode=DELETE;PRAGMA synchronous=NORMAL;' +
+    'CREATE TABLE IF NOT EXISTS metadata(name text,value text);' +
+    'CREATE TABLE IF NOT EXISTS tiles(zoom_level int,tile_column int,tile_row int,tile_data blob);' +
+    'CREATE UNIQUE INDEX IF NOT EXISTS tile_index ON tiles(zoom_level,tile_column,tile_row);' +
+    'BEGIN;\n');
+  var pending = 0;
+  function tmsRow(z, y) { return Math.pow(2, z) - 1 - y; }
+  return {
+    has: function (z, x, y) { return seen.has(z + '/' + x + '/' + tmsRow(z, y)); },
+    write: function (z, x, y, buf, cb) {
+      if (sqliteErr) return cb(sqliteErr);
+      var sql = "INSERT OR REPLACE INTO tiles VALUES(" + z + "," + x + "," + tmsRow(z, y) +
+        ",x'" + buf.toString('hex') + "');\n";
+      if (++pending % 500 === 0) proc.stdin.write('COMMIT;BEGIN;\n');
+      if (proc.stdin.write(sql)) cb(); else proc.stdin.once('drain', cb);
+    },
+    finalize: function (cb) {
+      var meta = {
+        name: 'CyclOSM', type: 'baselayer', version: '1.0', format: 'png',
+        description: 'CyclOSM static tiles',
+        bounds: [bMinLon, bMinLat, bMaxLon, bMaxLat].map(function (n) { return n.toFixed(6); }).join(','),
+        center: ((bMinLon + bMaxLon) / 2).toFixed(6) + ',' + ((bMinLat + bMaxLat) / 2).toFixed(6) + ',' +
+          Math.round((zMin + zMax) / 2),
+        minzoom: zMin, maxzoom: zMax
+      };
+      var m = 'COMMIT;\n';
+      Object.keys(meta).forEach(function (k) {
+        m += "INSERT OR REPLACE INTO metadata VALUES('" + k + "','" + String(meta[k]).replace(/'/g, "''") + "');\n";
+      });
+      m += '.quit\n';
+      proc.on('close', function () { cb(sqliteErr); });
+      proc.stdin.end(m);
+    }
+  };
+}
+
+var sink = OUTPUT === 'mbtiles' ? makeMbtilesSink() : makeDirSink();
+
+// Resumable: drop tiles already present in the sink.
+jobs = jobs.filter(function (t) { return !sink.has(t.z, t.x, t.y); });
+var total = jobs.length;
+console.log('[render] XML=' + XML + ' output=' + OUTPUT + ' concurrency=' + CONC);
+console.log('[render] ' + total + ' tiles to render (already-present skipped)');
+if (total === 0) {
+  sink.finalize(function (err) {
+    if (err) { console.error('[render] MBTiles write failed: ' + err.message); process.exit(3); }
+    console.log('[render] nothing to do.'); process.exit(0);
+  });
+  return;
+}
+
+// --- Render one tile with a pre-loaded map object ---
+function renderTile(map, job, done) {
+  var z = job.z, x = job.x, y = job.y;
+  map.zoomToBox([
+    lon2m(tile2lon(x, z)), lat2m(tile2lat(y + 1, z)),
+    lon2m(tile2lon(x + 1, z)), lat2m(tile2lat(y, z))
+  ]);
+  var im = new mapnik.Image(TILE, TILE);
+  map.render(im, {}, function (err, im) {
+    if (err) return done(err);
+    sink.write(z, x, y, im.encodeSync('png'), done);
+  });
+}
+
+// --- Worker pool: CONC map objects draining the job queue ---
+var next = 0, done = 0, failed = 0, active = 0;
+function dispatch(map) {
+  if (next >= jobs.length) { if (--active === 0) finish(); return; }
+  var job = jobs[next++];
+  renderTile(map, job, function (err) {
+    done++;
+    if (err) { failed++; console.error('[render] FAILED ' + job.z + '/' + job.x + '/' + job.y + ': ' + err.message); }
+    if (done % 200 === 0 || done === total) console.log('[render] ' + done + '/' + total + ' (' + failed + ' failed)');
+    dispatch(map);
+  });
+}
+
+var fatal = false;
+// Flush the sink and exit; guarded so concurrent worker failures finalize once.
+function abort(code, msg) {
+  if (fatal) return;
+  fatal = true;
+  if (msg) console.error(msg);
+  sink.finalize(function () { process.exit(code); });
+}
+
+function finish() {
+  if (fatal) return;
+  sink.finalize(function (err) {
+    if (err) { console.error('[render] MBTiles write failed: ' + err.message); process.exit(3); }
+    console.log('[render] done: ' + (total - failed) + ' rendered, ' + failed + ' failed' +
+      (OUTPUT === 'mbtiles' ? ' -> ' + MBTILES : ' -> ' + TILE_DIR));
+    process.exit(failed > 0 ? 1 : 0);
+  });
+}
+
+var workers = Math.max(1, Math.min(CONC, jobs.length));
+for (var i = 0; i < workers; i++) {
+  active++;
+  (function () {
+    var map = new mapnik.Map(TILE, TILE);
+    map.load(XML, { strict: false, base: BASE }, function (err, map) {
+      if (err) { abort(2, '[render] failed to load ' + XML + ': ' + err.message); return; }
+      map.bufferSize = 128;
+      dispatch(map);
+    });
+  })();
+}


### PR DESCRIPTION
CyclOSM is my go-to map when it comes to planning bike routes but unfortunately the openstreetmap.fr tile server is often sluggish to respond or doesn't work at all. So the main goal of this change is to allow anyone to run their own tile server using Docker/Podman:
* Modernize Docker images to support both amd64 and arm64 (I tested the full pipeline on Apple Silicon and Linux box with arm64 CPUs)
* Add a pipeline for pre-rendering raster tiles (still a resource-intensive process)
* Add support for Podman